### PR TITLE
fix lock file after error

### DIFF
--- a/src/core/FtpFileSystem.cpp
+++ b/src/core/FtpFileSystem.cpp
@@ -1303,8 +1303,15 @@ void TFTPFileSystem::Sink(const UnicodeString & FileName,
       {
         ThrowSkipFileNull();
       }
-      FileTransfer(FileName, DestFullName, LocalFileHandle, OnlyFileName,
-        FilePath, true, AFile->GetSize(), TransferType, UserData, OperationProgress);
+      try {
+        FileTransfer(FileName, DestFullName, LocalFileHandle, OnlyFileName,
+          FilePath, true, AFile->GetSize(), TransferType, UserData, OperationProgress);
+      }
+      catch (Exception & E)
+      {
+        ::CloseHandle(LocalFileHandle);
+        throw;
+      }
     }
 
     // in case dest filename is changed from overwrite dialog


### PR DESCRIPTION
если в момент начала копирования файла по ftp происходит разрыв соединения, то создается пустой файл. а его handle не освобождается. файл нельзя удалить без перезапуска фара. в случае же появления диалога "переподключится?" и успешном соединении происходит повторная попытка передачи файла, завершающаяся ошибкой "не могу создать файл".
как воспроизвести ошибку
1. ставим ftp-сервер. например filezilla
2. устанавливаем "connection timeout" в 5 секунд
3. подключаемся через netbox к серверу. 
4. вызываем диалог копирования файла. нажимаем ок через >=5 секунд
