### PR TITLE
PgUp/PgDn on num keyboard for session dialog

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -237,14 +237,11 @@ bool TTabbedDialog::Key(TFarDialogItem * /*Item*/, LONG_PTR KeyCode)
   bool Result = false;
   WORD Key = KeyCode & 0xFFFF;
   DWORD ControlState = KeyCode >> 16;
-  if (((Key == VK_NEXT) && (ControlState & CTRLMASK) != 0) ||
-      ((Key == VK_PRIOR) && (ControlState & CTRLMASK) != 0))
-  {
+  if ((((Key == VK_NEXT) || (Key == VK_NUMPAD3)) && (ControlState & CTRLMASK) != 0) ||
+    (((Key == VK_PRIOR) || (Key == VK_NUMPAD9)) && (ControlState & CTRLMASK) != 0)) {
     intptr_t NewTab = FTab;
-    do
-    {
-      if (Key == VK_NEXT)
-      {
+    do {
+      if ((Key == VK_NEXT) || (Key == VK_NUMPAD3)) {
         NewTab = NewTab == FTabCount - 1 ? 1 : NewTab + 1;
       }
       else


### PR DESCRIPTION
Вкладки не переключаются клавишами (Ctrl+PageUp/Ctrl+PageDown) на цифровой клавиатуре (при выключенном NumLock).
http://forum.farmanager.com/viewtopic.php?f=5&t=6317&p=116788#p116534
