### PR TITLE
Dont show exitcode

### DIFF
--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -5251,7 +5251,7 @@ public:
       break;
     case cotExitCode:
       FAction.ExitCode(ToInt(::StrToInt64(Str)));
-      break;
+      return;
     }
 
     if (FOutputEvent != nullptr)


### PR DESCRIPTION
Don't show exitcode (digit) after any command in Shell Session