### PR TITLE
Clean console outputs

### DIFF
--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -1413,11 +1413,28 @@ void TCustomFarPlugin::ShowTerminalScreen()
   if (Size.y >= 2)
   {
     // clean menu keybar area before command output
+    int Y = Size.y - 2;
+    // if any panel is visible -- clear all screen (don't scroll panel)
+    {
+      PanelInfo Info;
+      ClearStruct(Info);
+      FarControl(FCTL_GETPANELINFO, 0, ToIntPtr(&Info), PANEL_ACTIVE);
+      if(Info.Visible) 
+        goto clearall;
+      ClearStruct(Info);
+      FarControl(FCTL_GETPANELINFO, 0, ToIntPtr(&Info), PANEL_PASSIVE);
+      if(Info.Visible)
+      {
+clearall:
+        Y = 0;
+      }
+    }
     UnicodeString Blank = ::StringOfChar(L' ', static_cast<intptr_t>(Size.x));
-    for (int Y = Size.y - 2; Y < Size.y; Y++)
+    do
     {
       Text(0, Y, 7 /*LIGHTGRAY*/, Blank);
     }
+    while(++Y < Size.y);
   }
   FlushText();
 

--- a/src/NetBox/NetBox.rc
+++ b/src/NetBox/NetBox.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-FILEVERSION 2,4,5,531
-PRODUCTVERSION 2,4,5,531
+FILEVERSION 2,4,5,532
+PRODUCTVERSION 2,4,5,532
 FILEOS 0x4
 FILETYPE 0x2
 {
@@ -10,13 +10,13 @@ FILETYPE 0x2
         {
             VALUE "CompanyName", "Michael Lukashov\0"
             VALUE "FileDescription", "NetBox: SFTP/FTP/FTPS/SCP/WebDAV client for FAR2\0"
-            VALUE "FileVersion", "2.4.5.531\0"
+            VALUE "FileVersion", "2.4.5.532\0"
             VALUE "InternalName", "FarNetBox\0"
             VALUE "LegalCopyright", "(c) 2011, 2017 Michael Lukashov\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "NetBox.dll\0"
             VALUE "ProductName", "NetBox\0"
-            VALUE "ProductVersion", "2.4.5.531\0"
+            VALUE "ProductVersion", "2.4.5.532\0"
             VALUE "ReleaseType", "stable\0"
             VALUE "WWW", "https://github.com/michaellukashov/Far-NetBox\0"
         }

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -793,8 +793,10 @@ bool TWinSCPFileSystem::ProcessEventEx(intptr_t Event, void *Param)
 }
 
 void TWinSCPFileSystem::TerminalCaptureLog(
-  UnicodeString AddedLine, TCaptureOutputType /*OutputEvent*/)
+  UnicodeString AddedLine, TCaptureOutputType OutputEvent)
 {
+  if (OutputEvent == cotExitCode)
+    return;
   if (FOutputLog)
   {
     GetWinSCPPlugin()->FarWriteConsole(AddedLine + L"\n");

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -3099,7 +3099,7 @@ void TWinSCPFileSystem::TerminalInformation(
   if (Phase != 0)
   {
     TSessionStatus sts = GetTerminal() ? GetTerminal()->GetStatus() : ssClosed;
-    if (sts == ssOpening || (sts == ssOpened && Phase > 0))
+    if (sts == ssOpening || sts == ssOpened)
     {
       if (FAuthenticationLog == nullptr)
       {

--- a/src/NetBox/plugin_version.hpp
+++ b/src/NetBox/plugin_version.hpp
@@ -7,5 +7,5 @@
 #define NETBOX_VERSION_MAJOR         2
 #define NETBOX_VERSION_MINOR         4
 #define NETBOX_VERSION_PATCH         5
-#define NETBOX_VERSION_BUILD         531
+#define NETBOX_VERSION_BUILD         532
 

--- a/src/NetBox/resource.h
+++ b/src/NetBox/resource.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PLUGIN_VERSION_NUM 2,4,5,531
+#define PLUGIN_VERSION_NUM 2,4,5,532
 #define PLUGIN_VERSION_TXT "2.4.5"
 #define PLUGIN_VERSION_WTXT L"2.4.5"
 


### PR DESCRIPTION
1. Tune 'Shell open progress' - show commands in MessageBox
2. Tune 'Not show exitcode'  - don't show exitcode in 'execute-onecommand-mode (Ctrl-G)
3. Do not 'scroll panels' when execute remote command (clean screen if panel(s) is visible)
4. Increment build number (531=>532)
