### PR TITLE
Pseudo-echo for shell command

### DIFF
--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -1404,7 +1404,7 @@ void TCustomFarPlugin::ScrollTerminalScreen(int Rows)
   ::ScrollConsoleScreenBuffer(FConsoleOutput, &Source, nullptr, Dest, &Fill);
 }
 
-void TCustomFarPlugin::ShowTerminalScreen()
+void TCustomFarPlugin::ShowTerminalScreen(UnicodeString Command)
 {
   DebugAssert(!FTerminalScreenShowing);
   TPoint Size, Cursor;
@@ -1435,6 +1435,15 @@ clearall:
       Text(0, Y, 7 /*LIGHTGRAY*/, Blank);
     }
     while(++Y < Size.y);
+    if(Command.Length() && Size.x > 2)
+    {
+      Blank = Command;
+      Blank.Insert(0, L"$ ", 2);
+      if(Blank.Length() > Size.x) Blank.SetLength(Size.x);
+      if(Cursor.y == Y-1) --Cursor.y; // !'Show key bar'
+      Text(0, Cursor.y, 7 /*LIGHTGRAY*/, Blank);
+      ++Cursor.y;
+    }
   }
   FlushText();
 

--- a/src/NetBox/FarPlugin.h
+++ b/src/NetBox/FarPlugin.h
@@ -163,7 +163,7 @@ public:
   void ClearConsoleTitle();
   void UpdateConsoleTitle(UnicodeString Title);
   void UpdateConsoleTitleProgress(short Progress);
-  void ShowTerminalScreen();
+  void ShowTerminalScreen(UnicodeString Command);
   void SaveTerminalScreen();
   void ScrollTerminalScreen(int Rows);
   TPoint TerminalInfo(TPoint *Size = nullptr, TPoint *Cursor = nullptr) const;

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -897,7 +897,7 @@ bool TWinSCPFileSystem::ExecuteCommand(UnicodeString Command)
           WinSCPPlugin->SaveTerminalScreen();
           WinSCPPlugin->ClearConsoleTitle();
         };
-        WinSCPPlugin->ShowTerminalScreen();
+        WinSCPPlugin->ShowTerminalScreen(Command);
 
         FOutputLog = true;
         FTerminal->AnyCommand(Command, nb::bind(&TWinSCPFileSystem::TerminalCaptureLog, this));
@@ -1228,7 +1228,7 @@ void TWinSCPFileSystem::ApplyCommand()
               };
               if (FLAGSET(Params, ccShowResults))
               {
-                GetWinSCPPlugin()->ShowTerminalScreen();
+                GetWinSCPPlugin()->ShowTerminalScreen(Command);
               }
 
               FTerminal->CustomCommandOnFiles(Command, Params, FileList.get(), OutputEvent);


### PR DESCRIPTION
 When execute user command print it (prepended by '$ ') before it output.

 This behavior is necessary for the case when the screen is cleared
partially - 'command echo' atcs as a 'divider' between output of
different commands.

 An example is two consecutive make commands, the first one ended with a
error message, and the second without (any output).