### PR TITLE
Fix numerous bugs in view/change file attributes dialog

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4721,19 +4721,21 @@ TPropertiesDialog::TPropertiesDialog(TCustomFarPlugin * AFarPlugin,
   FMultiple = (AFileList->GetCount() > 1);
 
   {
-    std::unique_ptr<TStringList> UsedGroupList;
-    std::unique_ptr<TStringList> UsedUserList;
-    if ((GroupList == nullptr) || (GroupList->GetCount() == 0))
+    std::unique_ptr<TStringList> UsedGroupList = std::make_unique<TStringList>();
+    std::unique_ptr<TStringList> UsedUserList = std::make_unique<TStringList>();
+    UsedGroupList->SetDuplicates(dupIgnore);
+    UsedGroupList->SetSorted(true);
+    UsedUserList->SetDuplicates(dupIgnore);
+    UsedUserList->SetSorted(true);
+
+    for (int32_t Index = 0; Index < UserList->GetCount(); ++Index)
     {
-      UsedGroupList = std::make_unique<TStringList>();
-      UsedGroupList->SetDuplicates(dupIgnore);
-      UsedGroupList->SetSorted(true);
+        UsedUserList->Add(UserList->Token(Index)->GetName());
     }
-    if ((UserList == nullptr) || (UserList->GetCount() == 0))
+
+    for (int32_t Index = 0; Index < GroupList->GetCount(); ++Index)
     {
-      UsedUserList = std::make_unique<TStringList>();
-      UsedUserList->SetDuplicates(dupIgnore);
-      UsedUserList->SetSorted(true);
+        UsedGroupList->Add(GroupList->Token(Index)->GetName());
     }
 
     int32_t Directories = 0;
@@ -4808,13 +4810,6 @@ TPropertiesDialog::TPropertiesDialog(TCustomFarPlugin * AFarPlugin,
     {
       OwnerComboBox->GetItems()->Assign(UsedUserList.get());
     }
-    else if (UserList)
-    {
-      for (int32_t Index = 0; Index < UserList->GetCount(); ++Index)
-      {
-        OwnerComboBox->GetItems()->Add(UserList->Token(Index)->GetName());
-      }
-    }
 
     SetNextItemPosition(ipNewLine);
 
@@ -4830,13 +4825,6 @@ TPropertiesDialog::TPropertiesDialog(TCustomFarPlugin * AFarPlugin,
     if (UsedGroupList.get())
     {
       GroupComboBox->GetItems()->Assign(UsedGroupList.get());
-    }
-    else if (GroupList)
-    {
-      for (int32_t Index = 0; Index < GroupList->GetCount(); ++Index)
-      {
-        GroupComboBox->GetItems()->Add(GroupList->Token(Index)->GetName());
-      }
     }
 
     SetNextItemPosition(ipNewLine);

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4721,8 +4721,8 @@ TPropertiesDialog::TPropertiesDialog(TCustomFarPlugin * AFarPlugin,
   FMultiple = (AFileList->GetCount() > 1);
 
   {
-    std::unique_ptr<TStrings> UsedGroupList;
-    std::unique_ptr<TStrings> UsedUserList;
+    std::unique_ptr<TStringList> UsedGroupList;
+    std::unique_ptr<TStringList> UsedUserList;
     if ((GroupList == nullptr) || (GroupList->GetCount() == 0))
     {
       UsedGroupList = std::make_unique<TStringList>();

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4783,6 +4783,7 @@ TPropertiesDialog::TPropertiesDialog(TCustomFarPlugin * AFarPlugin,
     const TRemoteFile * File = AFileList->GetAs<TRemoteFile>(0);
     if (!File->GetLinkTo().IsEmpty())
     {
+      SetHeight(GetHeight() + 1);
       Text = new TFarText(this);
       Text->SetCaption(GetMsg(NB_PROPERTIES_LINKTO));
 

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4358,6 +4358,7 @@ public:
     TFarDialogItem * EnabledDependency);
 protected:
   bool FAnyDirectories{false};
+  bool Recursive{false};
   TFarCheckBox * FCheckBoxes[12]{};
   TRights::TState FFixedStates[12]{};
   TFarEdit * FOctalEdit{nullptr};
@@ -4368,6 +4369,7 @@ protected:
 
 public:
   TRights GetRights();
+  void SetRecursive(bool ARecursive);
   void SetRights(const TRights & Value);
   void SetAddXToDirectories(bool Value);
   bool GetAddXToDirectories() const;
@@ -4533,8 +4535,12 @@ void TRightsContainer::UpdateControls()
 
     if (FDirectoriesXCheck)
     {
-      FDirectoriesXCheck->SetEnabled(
+      FDirectoriesXCheck->SetEnabled(Recursive ||
         !((R.GetNumberSet() & TRights::rfExec) == TRights::rfExec));
+      if (!Recursive && (R.GetNumberSet() & TRights::rfExec) == TRights::rfExec)
+      {
+        SetAddXToDirectories(false);
+      }
     }
 
     if (!FOctalEdit->Focused())
@@ -4622,6 +4628,14 @@ TRights TRightsContainer::GetRights()
       GetStates(static_cast<TRights::TRight>(Right)));
   }
   return Result;
+}
+
+void TRightsContainer::SetRecursive(bool ARecursive)
+{
+  if (Recursive != ARecursive)
+  {
+    Recursive = ARecursive;
+  }
 }
 
 void TRightsContainer::SetRights(const TRights & Value)
@@ -4931,6 +4945,7 @@ void TPropertiesDialog::UpdateProperties(TRemoteProperties & Properties) const
 #undef STORE_NAME
 
   Properties.Recursive = RecursiveCheck != nullptr && RecursiveCheck->GetChecked();
+  RightsContainer->SetRecursive(Properties.Recursive);
 }
 
 bool TPropertiesDialog::Execute(TRemoteProperties * Properties)

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -1879,6 +1879,10 @@ void TWinSCPFileSystem::FileProperties()
       {
         Flags |= cpGroup;
       }
+      if (FTerminal->GetIsCapable(fcGroupOwnerChangingByID))
+      {
+        Flags |= cpIDs;
+      }
 
       TRemoteProperties NewProperties = CurrentProperties;
       if (PropertiesDialog(FileList.get(), FTerminal->RemoteGetCurrentDirectory(),

--- a/src/base/Classes.cpp
+++ b/src/base/Classes.cpp
@@ -532,12 +532,10 @@ int32_t TStringList::AddObject(const UnicodeString & S, const TObject * AObject)
         Error(SDuplicateString, 2);
         break;
       case dupAccept:
-        Result = GetCount();
+        ++Result;
         break;
       }
     }
-    else
-      Result = GetCount();
   }
   InsertItem(Result, S, AObject);
   return Result;
@@ -546,12 +544,11 @@ int32_t TStringList::AddObject(const UnicodeString & S, const TObject * AObject)
 bool TStringList::Find(const UnicodeString & S, int32_t & Index) const
 {
   bool Result = false;
-  Index = nb::NPOS;
   if (GetSorted())
   {
     int32_t L = 0;
-    int32_t H = GetCount() - 1;
-    while ((H != nb::NPOS) && (L <= H))
+    int32_t H = GetCount();
+    while (L < H)
     {
       const int32_t Idx = (L + H) >> 1;
       const int32_t C = CompareStrings(FStrings[Idx], S);
@@ -559,23 +556,22 @@ bool TStringList::Find(const UnicodeString & S, int32_t & Index) const
       {
         L = Idx + 1;
       }
+      else if (C == 0)
+      {
+        Index = Idx;
+        return true;
+      }
       else
       {
-        H = Idx - 1;
-        if (C == 0)
-        {
-          Result = true;
-          Index = L;
-          if (FDuplicates != dupAccept)
-          {
-            L = Idx;
-          }
-        }
+        H = Idx;
       }
     }
+    Index = H;
+    return false;
   }
   else
   {
+    Index = GetCount();
     for (int32_t Idx = 0; Idx < GetCount(); Idx++)
     {
       const int32_t C = CompareStrings(FStrings[Idx], S);

--- a/src/core/FileSystems.h
+++ b/src/core/FileSystems.h
@@ -18,7 +18,7 @@ struct TLocalFileHandle;
 
 enum TFSCommand { fsNull = 0, fsVarValue, fsLastLine, fsFirstLine,
   fsCurrentDirectory, fsChangeDirectory, fsListDirectory, fsListCurrentDirectory,
-  fsListFile, fsLookupUsersGroups, fsCopyToRemote, fsCopyToLocal, fsDeleteFile,
+  fsListFile, fsLookupUsersGroups, fsWhoami, fsCopyToRemote, fsCopyToLocal, fsDeleteFile,
   fsRenameFile, fsCreateDirectory, fsChangeMode, fsChangeGroup, fsChangeOwner,
   fsHomeDirectory, fsUnset, fsUnalias, fsCreateLink, fsCopyFile,
   fsAnyCommand, fsLang, fsReadSymlink, fsChangeProperties, fsMoveFile,

--- a/src/core/FtpFileSystem.cpp
+++ b/src/core/FtpFileSystem.cpp
@@ -1119,10 +1119,10 @@ void TFTPFileSystem::ChangeFileProperties(const UnicodeString & AFileName,
   TChmodSessionAction & Action)
 {
   DebugAssert(Properties);
-  DebugAssert(Properties && !Properties->Valid.Contains(vpGroup)); //-V595
-  DebugAssert(Properties && !Properties->Valid.Contains(vpOwner)); //-V595
-  DebugAssert(Properties && !Properties->Valid.Contains(vpLastAccess)); //-V595
-  DebugAssert(Properties && !Properties->Valid.Contains(vpModification)); //-V595
+  // DebugAssert(Properties && !Properties->Valid.Contains(vpGroup)); //-V595
+  // DebugAssert(Properties && !Properties->Valid.Contains(vpOwner)); //-V595
+  // DebugAssert(Properties && !Properties->Valid.Contains(vpLastAccess)); //-V595
+  // DebugAssert(Properties && !Properties->Valid.Contains(vpModification)); //-V595
 
   if (Properties && Properties->Valid.Contains(vpRights))
   {

--- a/src/core/RemoteFiles.cpp
+++ b/src/core/RemoteFiles.cpp
@@ -2254,18 +2254,12 @@ TRights::TRights() noexcept
 {
   SetNumber(0);
   FAllowUndef = false;
-  FSet = 0;
-  FUnset = 0;
-  Number = 0;
-  FUnknown = true;
 }
 
 TRights::TRights(uint16_t ANumber) noexcept
 {
   SetNumber(ANumber);
   FAllowUndef = false;
-  FSet = 0;
-  FUnset = 0;
 }
 
 TRights::TRights(const TRights & Source) noexcept

--- a/src/core/RemoteFiles.cpp
+++ b/src/core/RemoteFiles.cpp
@@ -691,7 +691,7 @@ int32_t TRemoteToken::Compare(const TRemoteToken & rhs) const
 void TRemoteToken::SetID(int32_t Value)
 {
   FID = Value;
-  FIDValid = Value != 0;
+  FIDValid = true;
 }
 
 bool TRemoteToken::GetNameValid() const

--- a/src/core/ScpFileSystem.cpp
+++ b/src/core/ScpFileSystem.cpp
@@ -479,6 +479,7 @@ bool TSCPFileSystem::IsCapable(int32_t Capability) const
     case fcPreservingTimestampUpload:
     case fcGroupChanging:
     case fcOwnerChanging:
+    case fcGroupOwnerChangingByID:
     case fcAnyCommand:
     case fcShellAnyCommand:
     case fcHardLink:
@@ -504,7 +505,6 @@ bool TSCPFileSystem::IsCapable(int32_t Capability) const
     case fcCheckingSpaceAvailable:
     case fcIgnorePermErrors:
     case fcSecondaryShell: // has fcShellAnyCommand
-    case fcGroupOwnerChangingByID: // by name
     case fcMoveToQueue:
     case fcLocking:
     case fcPreservingTimestampDirs:

--- a/src/core/ScpFileSystem.cpp
+++ b/src/core/ScpFileSystem.cpp
@@ -139,6 +139,7 @@ const TCommandType DefaultCommandSet[ShellCommandCount] =
   /*ListCurrentDirectory*/{ -1, -1, F, F, F, "%s %s" /* listing command, options */ },
   /*ListFile*/            {  1,  1, F, F, F, "%s -d %s \"%s\"" /* listing command, options, file/directory */ },
   /*LookupUserGroups*/    {  0,  1, F, F, F, "groups" },
+  /*Whoami*/              {  0,  1, F, F, F, "whoami" },
   /*CopyToRemote*/        { -1, -1, T, F, T, "scp -r %s -d -t \"%s\"" /* options, directory */ },
   /*CopyToLocal*/         { -1, -1, F, F, T, "scp -r %s -d -f \"%s\"" /* options, file */ },
   /*DeleteFile*/          {  0,  0, T, F, F, "rm -f -r \"%s\"" /* file/directory */},
@@ -855,8 +856,14 @@ void TSCPFileSystem::SkipStartupMessage()
 
 void TSCPFileSystem::LookupUsersGroups()
 {
-  ExecCommand(fsLookupUsersGroups, 0);
+  ExecCommand(fsWhoami, 0);
   FTerminal->GetUsers()->Clear();
+  if (FOutput->GetCount() > 0)
+  {
+    UnicodeString CurrentUser = FOutput->GetString(0);
+    FTerminal->GetUsers()->Add(TRemoteToken(CurrentUser));
+  }
+  ExecCommand(fsLookupUsersGroups, 0);
   FTerminal->GetGroups()->Clear();
   if (FOutput->GetCount() > 0)
   {

--- a/src/core/SftpFileSystem.cpp
+++ b/src/core/SftpFileSystem.cpp
@@ -2247,7 +2247,6 @@ bool TSFTPFileSystem::IsCapable(int32_t Capability) const
     case fcOwnerChanging:
     case fcGroupChanging:
       return
-        (FVersion <= 3) ||
         ((FVersion >= 4) &&
          (!FSupport->Loaded ||
           FLAGSET(FSupport->AttributeMask, SSH_FILEXFER_ATTR_OWNERGROUP)));

--- a/src/windows/WinInterface.h
+++ b/src/windows/WinInterface.h
@@ -339,6 +339,7 @@ constexpr int32_t cpMode =  0x01;
 constexpr int32_t cpOwner = 0x02;
 constexpr int32_t cpGroup = 0x04;
 constexpr int32_t cpAcl =   0x08;
+constexpr int32_t cpIDs =   0x10;
 using TCalculateSizeEvent = nb::FastDelegate4<void,
   TStrings * /*FileList*/, int64_t & /*Size*/, TCalculateSizeStats & /*Stats*/,
   bool & /*Close*/>;


### PR DESCRIPTION
Fix bugs and add some improvements.

Bugs:

- file mode is shown incorrectly
- file mode cannot be correctly changed
- owner and group cannot be changed
- cannot set user and group in SFTP mode (SFTP protocol v3, e.g. openssh)
- owner and group drop down list contains repeated items
- FTP change attributes assertion
- add X to directories + recursive checkboxes misbehaviour
- ok button misbehaviour
- recursive checkbox is invisible when file is symlink
- adding object into sorted TStringsList is broken

Improvements:
- enrich owner and group combo boxes with any possible names
- add logged on user to a users list for owner combo box
- add numeric textboxes for changing uid and gid for servers that can only use numeric values