### PR TITLE
Several small fixes

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -3775,7 +3775,7 @@ bool TSessionDialog::Execute(TSessionData * SessionData, TSessionActionEnum Acti
 
     for (int32_t Index6 = 0; Index6 < KEX_COUNT; ++Index6)
     {
-      SessionData->SetKex(Index6, static_cast<TKex>(nb::ToUIntPtr(KexListBox->GetItems()->GetObj(Index))));
+      SessionData->SetKex(Index6, static_cast<TKex>(nb::ToUIntPtr(KexListBox->GetItems()->GetObj(Index6))));
     }
 
     // Authentication tab

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -1488,7 +1488,7 @@ public:
   explicit TSessionDialog(TCustomFarPlugin * AFarPlugin, TSessionActionEnum Action) noexcept;
   virtual ~TSessionDialog() noexcept override;
 
-  bool Execute(TSessionData * SessionData, TSessionActionEnum Action);
+  bool Execute(TSessionData * SessionData, TSessionActionEnum & Action);
 
 protected:
   virtual void Change() override;
@@ -3147,7 +3147,7 @@ void TSessionDialog::UpdateControls()
   TunnelTab->SetEnabled(InternalSshProtocol);
 }
 
-bool TSessionDialog::Execute(TSessionData * SessionData, TSessionActionEnum Action)
+bool TSessionDialog::Execute(TSessionData * SessionData, TSessionActionEnum & Action)
 {
   constexpr int32_t Captions[] =
   {
@@ -4338,7 +4338,7 @@ int32_t TSessionDialog::AddTab(int32_t TabID, const UnicodeString & TabCaption)
 }
 
 bool TWinSCPFileSystem::SessionDialog(TSessionData * SessionData,
-  TSessionActionEnum Action)
+  TSessionActionEnum & Action)
 {
   std::unique_ptr<TSessionDialog> Dialog(std::make_unique<TSessionDialog>(FPlugin, Action));
   const bool Result = Dialog->Execute(SessionData, Action);

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -5801,6 +5801,7 @@ private:
 TLinkDialog::TLinkDialog(TCustomFarPlugin * AFarPlugin,
   bool Edit, bool AllowSymbolic) : TFarDialog(AFarPlugin)
 {
+  TFarDialog::InitDialog();
   SetSize(TPoint(76, 12));
   const TRect CRect = GetClientRect();
 

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -2564,7 +2564,7 @@ TSessionDialog::TSessionDialog(TCustomFarPlugin * AFarPlugin, TSessionActionEnum
       for (int32_t Index4 = GetConfiguration()->GetTunnelLocalPortNumberLow();
         Index4 <= GetConfiguration()->GetTunnelLocalPortNumberHigh(); ++Index4)
       {
-        TunnelLocalPortNumberEdit->GetItems()->Add(::IntToStr(Index1));
+        TunnelLocalPortNumberEdit->GetItems()->Add(::IntToStr(Index4));
       }
     }
     __finally

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -7848,6 +7848,7 @@ TSynchronizeDialog::TSynchronizeDialog(TCustomFarPlugin * AFarPlugin,
   uint32_t Options, uint32_t CopyParamAttrs, TGetSynchronizeOptionsEvent && OnGetOptions) :
   TFarDialog(AFarPlugin)
 {
+  TFarDialog::InitDialog();
   FSynchronizing = false;
   FStarted = false;
   FOnStartStop = OnStartStop;

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -2263,7 +2263,6 @@ TSessionDialog::TSessionDialog(TCustomFarPlugin * AFarPlugin, TSessionActionEnum
   Separator->SetPosition(GroupTop);
   Separator->SetCaption(GetMsg(NB_LOGIN_CONNECTION_GROUP));
 
-  Text = new TFarText(this);
   SetNextItemPosition(ipNewLine);
 
   SshBufferSizeCheck = new TFarCheckBox(this);

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -1698,7 +1698,7 @@ TSessionDialog::TSessionDialog(TCustomFarPlugin * AFarPlugin, TSessionActionEnum
   FTabs(std::make_unique<TObjectList>()),
   FFirstVisibleTabIndex(0)
 {
-  TPoint S = TPoint(67, 23);
+  TPoint S = TPoint(67, 25);
   bool Limited = (S.y > GetMaxSize().y);
   if (Limited)
   {

--- a/src/NetBox/WinSCPFileSystem.h
+++ b/src/NetBox/WinSCPFileSystem.h
@@ -126,7 +126,7 @@ protected:
   TWinSCPPlugin * GetWinSCPPlugin();
   void ShowOperationProgress(TFileOperationProgressType & ProgressData,
     bool Force);
-  bool SessionDialog(TSessionData * SessionData, TSessionActionEnum Action);
+  bool SessionDialog(TSessionData * SessionData, TSessionActionEnum & Action);
   void EditConnectSession(TSessionData * Data, bool Edit);
   void EditConnectSession(TSessionData * Data, bool Edit, bool NewData, bool FillInConnect);
   void DuplicateOrRenameSession(TSessionData * Data,

--- a/src/NetBox/WinSCPPlugin.cpp
+++ b/src/NetBox/WinSCPPlugin.cpp
@@ -78,6 +78,7 @@ TWinSCPPlugin::~TWinSCPPlugin() noexcept
   {
     // GetFarConfiguration()->SetPlugin(nullptr);
     CoreFinalize();
+    FInitialized = false;
   }
   // DEBUG_PRINTF("begin");
 }


### PR DESCRIPTION
This fixes many small bugs

- 2 crashes of dialogs
- incorrect local tunnel port combobox items
- incorrect setting of selected kex
- excessive line in the session dialog
- invisible checkbox that is covered by a list
- "connect" button doesn't work