### PR TITLE
Fix TStringList::Find to pass tests

### DIFF
--- a/src/base/Classes.hpp
+++ b/src/base/Classes.hpp
@@ -510,7 +510,7 @@ public:
   void QuickSort(int32_t L, int32_t R, TStringListSortCompare SCompare);
 
   virtual void Assign(const TPersistent * Source) override;
-  virtual bool Find(const UnicodeString & S, int32_t & Index) const;
+  virtual bool Find(const UnicodeString & S, int32_t & Index, bool leftmost = true) const;
   virtual int32_t IndexOf(const UnicodeString & S) const override;
   virtual void Delete(int32_t Index) override;
   virtual void InsertObject(int32_t Index, const UnicodeString & Key, TObject * AObject) override;


### PR DESCRIPTION
Recent commit introduced a discrepancy in how Find function is used in tests. This new commit fixes it.