### PR TITLE
Fix slow session load

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -998,6 +998,16 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
       }
       Handled = true;
     }
+
+    if (Key == 'R' && (ControlState & CTRLMASK))
+    {
+      DeleteStoredSessions();
+      if (UpdatePanel())
+      {
+        RedrawPanel();
+      }
+      Handled = true;
+    }
   }
   else if (Connected())
   {

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -521,8 +521,10 @@ bool TWinSCPFileSystem::GetFindDataEx(TObjectList * PanelItems, OPERATION_MODES 
   else if (IsSessionList())
   {
     Result = true;
-    DebugAssert(GetStoredSessions());
+    bool JustLoaded = false;
+    GetStoredSessions(&JustLoaded);
     bool SessionList = true;
+    if (!JustLoaded)
     {
       std::unique_ptr<THierarchicalStorage> Storage(GetConfiguration()->CreateScpStorage(SessionList));
       if (Storage->OpenSubKey(GetConfiguration()->GetStoredSessionsSubKey(), False))

--- a/src/core/CoreMain.cpp
+++ b/src/core/CoreMain.cpp
@@ -168,11 +168,13 @@ void DeleteConfiguration()
 
 static bool StoredSessionsInitialized = false;
 
-TStoredSessionList * GetStoredSessions()
+TStoredSessionList * GetStoredSessions(bool * JustLoaded)
 {
+#define SET_LOADED(Value) { if (JustLoaded != nullptr) *JustLoaded = Value; }
   static TStoredSessionList * StoredSessions = nullptr;
   if (StoredSessionsInitialized)
   {
+    SET_LOADED(false);
     return StoredSessions;
   }
 
@@ -192,6 +194,8 @@ TStoredSessionList * GetStoredSessions()
     ShowExtendedException(&E);
   }
   StoredSessionsInitialized = true;
+  SET_LOADED(true);
+#undef SET_LOADED
   return StoredSessions;
 }
 

--- a/src/core/CoreMain.cpp
+++ b/src/core/CoreMain.cpp
@@ -171,8 +171,10 @@ static bool StoredSessionsInitialized = false;
 TStoredSessionList * GetStoredSessions()
 {
   static TStoredSessionList * StoredSessions = nullptr;
-  if (StoredSessions != nullptr)
+  if (StoredSessionsInitialized)
+  {
     return StoredSessions;
+  }
 
   StoredSessions = new TStoredSessionList();
 
@@ -195,12 +197,10 @@ TStoredSessionList * GetStoredSessions()
 
 void DeleteStoredSessions()
 {
-  static bool StoredSessionsDeleted = false;
-  if (!StoredSessionsDeleted && StoredSessionsInitialized)
+  if (StoredSessionsInitialized)
   {
     TStoredSessionList * StoredSessions = GetStoredSessions();
     SAFE_DESTROY(StoredSessions);
-    StoredSessionsDeleted = true;
     StoredSessionsInitialized = false;
   }
 }

--- a/src/core/CoreMain.h
+++ b/src/core/CoreMain.h
@@ -17,7 +17,7 @@ NB_CORE_EXPORT void CoreSetResourceModule(void * ResourceHandle);
 NB_CORE_EXPORT void CoreMaintenanceTask();
 void CoreUpdateFinalStaticUsage();
 TConfiguration * GetConfiguration();
-TStoredSessionList * GetStoredSessions();
+TStoredSessionList * GetStoredSessions(bool * JustLoaded = nullptr);
 void DeleteStoredSessions();
 
 NB_CORE_EXPORT UnicodeString NeonVersion();

--- a/src/core/NamedObjs.cpp
+++ b/src/core/NamedObjs.cpp
@@ -136,7 +136,7 @@ int32_t TNamedObjectList::Add(TObject * AObject)
       } 
       else 
       {
-        Result= Pos - 1;
+        Result = Pos - 1;
       }
     }
     else 
@@ -172,7 +172,7 @@ TNamedObject * TNamedObjectList::GetSortObject(const UnicodeString & Name, int32
   // bool Flag = false;
   int32_t L = 0;
   int32_t R = GetCountIncludingHidden() - 1;
-  int32_t Mid=0;
+  int32_t Mid = 0;
   Position = 0;
 
   if (R < 0)

--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -5357,10 +5357,10 @@ void TStoredSessionList::Load(THierarchicalStorage * Storage,
               SessionData->CopyData(GetDefaultSettings());
             }
             SessionData->SetName(SessionName);
+            SessionData->Load(Storage, PuttyImport);
             Add(SessionData);
           }
           Loaded->Add(SessionData);
-          SessionData->Load(Storage, PuttyImport);
           if (AsModified)
           {
             SessionData->SetModified(true);

--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -5306,7 +5306,7 @@ void TStoredSessionList::Load(THierarchicalStorage * Storage,
   try__finally
   {
     DebugAssert(FAutoSort);
-    FAutoSort = false;
+    // FAutoSort = false;
     const bool WasEmpty = (GetCount() == 0);
 
     Storage->GetSubKeyNames(SubKeys.get());
@@ -5383,8 +5383,9 @@ void TStoredSessionList::Load(THierarchicalStorage * Storage,
   }
   __finally
   {
-    FAutoSort = true;
-    AlphaSort();
+    // FAutoSort = true;
+    // AlphaSort();
+    Recount();
     // delete SubKeys;
     // delete Loaded;
   } end_try__finally

--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -4472,6 +4472,7 @@ static void FreeIEProxyConfig(WINHTTP_CURRENT_USER_IE_PROXY_CONFIG * IEProxyConf
 
 void TSessionData::PrepareProxyData() const
 {
+#if 0
 //  if ((GetProxyMethod() == pmSystem) && (nullptr == FIEProxyConfig))
   {
     FIEProxyConfig = new TIEProxyConfig;
@@ -4511,6 +4512,7 @@ void TSessionData::PrepareProxyData() const
       }
     }
   }
+#endif // #if 0
 }
 
 void TSessionData::ParseIEProxyConfig() const


### PR DESCRIPTION
This pull request:

- Fixes initial slow loading of sessions
- Prevents session reloading if it's already loaded
- Introduces `Ctrl-R` hotkey to force sessions reload
- Fixes sorting
- Prevents loading sessions twice in a row (on initial session load)
