### PR TITLE
Fix ClosePanel problems

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -808,13 +808,7 @@ bool TWinSCPFileSystem::ProcessPanelEventEx(intptr_t Event, void * Param)
       }
     }
   }
-  else
-  {
-    if (Event == FE_CLOSE && !FClosed)
-    {
-      ClosePanel();
-    }
-  }
+  // otherwise, don't call ClosePanel upon receiving FE_CLOSE
   return Result;
 }
 

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -788,7 +788,21 @@ bool TWinSCPFileSystem::ProcessPanelEventEx(intptr_t Event, void * Param)
       // Control(FCTL_CLOSEPLUGIN) does not seem to close plugin when called from
       // ProcessPanelEvent(FE_IDLE). So if TTerminal::Idle() causes session to close
       // we must count on having ProcessPanelEvent(FE_IDLE) called again.
-      FTerminal->Idle();
+      try
+      {
+        FTerminal->Idle();
+      }
+      catch (EConnectionFatal & E)
+      {
+        if (FTerminal->QueryReopen(&E, 0, nullptr))
+        {
+          UpdatePanel();
+        }
+        else
+        {
+          ClosePanel();
+        }
+      }
       if (FQueue != nullptr)
       {
         FQueue->Idle();


### PR DESCRIPTION
This fixes these bugs:

- When modal dialog is opened (e.g. edit session dialog) then closing `Far` window (with mouse or through system menu) results in assertion `FAccuired == 0`
- When connection is unexpectedly closed (while no operation is carried on the server) this leads to a disconnect but the panel is not closed
