### PR TITLE
Fix several crashes

### DIFF
--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -849,13 +849,13 @@ intptr_t TCustomFarPlugin::ProcessEditorInput(const struct ProcessEditorInputInf
 
 int32_t TCustomFarPlugin::MaxMessageLines() const
 {
-  return std::min<int32_t>(1, TerminalInfo().y - 5);
+  return std::max<int32_t>(1, TerminalInfo().y - 5);
 }
 
 int32_t TCustomFarPlugin::MaxMenuItemLength() const
 {
   // got from maximal length of path in FAR's folders history
-  return std::min<int32_t>(10, TerminalInfo().x - 13);
+  return std::max<int32_t>(10, TerminalInfo().x - 13);
 }
 
 int32_t TCustomFarPlugin::MaxLength(TStrings * Strings) const

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -2085,6 +2085,18 @@ void TWinSCPFileSystem::ClearCaches()
   FTerminal->ClearCaches();
 }
 
+void TWinSCPFileSystem::ClearConnectedState()
+{
+  FPathHistory->Clear();
+  FLastPath.Clear();
+  FEditHistories.clear();
+  FMultipleEdits.clear();
+  FOriginalEditFile.Clear();
+  FLastEditFile.Clear();
+  FLastMultipleEditFile.Clear();
+  FLastEditorID = -1;
+}
+
 void TWinSCPFileSystem::OpenSessionInPutty()
 {
   DebugAssert(Connected());
@@ -3108,6 +3120,7 @@ void TWinSCPFileSystem::Disconnect()
     GetSessionData()->SetSynchronizeBrowsing(FSynchronisingBrowse);
   }
   SAFE_DESTROY(FTerminal);
+  ClearConnectedState();
 }
 
 void TWinSCPFileSystem::ConnectTerminal(TTerminal * Terminal)

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -4276,9 +4276,13 @@ void TWinSCPFileSystem::EditHistory()
     const UnicodeString FullFileName =
       TUnixPath::Join(EditHistory.Directory, EditHistory.FileName);
     TRemoteFile * File = FTerminal->ReadFile(FullFileName);
+    if (File == nullptr)
+    {
+      // File is deleted, moved, etc
+      return;
+    }
     std::unique_ptr<TRemoteFile> FilePtr(File);
-    DebugAssert(FilePtr.get());
-    if (File && !File->GetHaveFullFileName())
+    if (!File->GetHaveFullFileName())
     {
       File->SetFullFileName(FullFileName);
     }

--- a/src/NetBox/WinSCPFileSystem.h
+++ b/src/NetBox/WinSCPFileSystem.h
@@ -201,6 +201,7 @@ protected:
   void RequireLocalPanel(const TFarPanelInfo * Panel, const UnicodeString & Message);
   bool AreCachesEmpty() const;
   void ClearCaches();
+  void ClearConnectedState();
   void OpenSessionInPutty();
   void QueueShow(bool ClosingPlugin);
   TTerminalQueueStatus * ProcessQueue(bool Hidden);


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/443)

- When returning from a connection to the session list and then establishing the new connection, the latter will use old local path and edit histories
- When returning from a connection to the session list with an open editor (editing a remote file), saving the file leads to a crash
- Selecting non-existent file from edit history leads to a crash
- History menu truncates names longer than 10 characters