### PR TITLE
Fix regression: closing FTP does not completely clear the session

### DIFF
--- a/src/core/FtpFileSystem.cpp
+++ b/src/core/FtpFileSystem.cpp
@@ -621,18 +621,19 @@ void TFTPFileSystem::Close()
   DebugAssert(FActive);
 
   bool Result = DoQuit();
-  if (Result)
-    return;
-  bool Opening = (FTerminal->GetStatus() == ssOpening);
-  if (FFileZillaIntf->Close(Opening))
+  if (!Result)
   {
-    DebugCheck(FLAGSET(WaitForCommandReply(false), TFileZillaIntf::REPLY_DISCONNECTED));
-    Result = true;
-  }
-  else
-  {
-    // See TFileZillaIntf::Close
-    Result = Opening;
+    bool Opening = (FTerminal->GetStatus() == ssOpening);
+    if (FFileZillaIntf->Close(Opening))
+    {
+      DebugCheck(FLAGSET(WaitForCommandReply(false), TFileZillaIntf::REPLY_DISCONNECTED));
+      Result = true;
+    }
+    else
+    {
+      // See TFileZillaIntf::Close
+      Result = Opening;
+    }
   }
 
   if (DebugAlwaysTrue(Result))


### PR DESCRIPTION
There is a periodical assertion `FReply == 0` in debug version when exiting the FTP session. It occurs because the FTP session is not completely cleared.

The pull request provides fix to this.