### PR TITLE
Relax file naming restrictions

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -5784,12 +5784,14 @@ bool TCopyDialog::Execute(UnicodeString & TargetDirectory,
     const UnicodeString Directory = FToRemote ?
       base::UnixIncludeTrailingBackslash(TargetDirectory) :
       ::IncludeTrailingBackslash(TargetDirectory);
+#if defined(__BORLANDC__)
     if (FFileList->GetCount() == 1)
     {
       UnicodeString DestFileName = FFileList->GetString(0);
       DestFileName = FToRemote ? DestFileName : FCopyParams.ChangeFileName(DestFileName, osRemote, true);
       FileMask = base::ExtractFileName(DestFileName, false);
     }
+#endif // defined(__BORLANDC__)
     DirectoryEdit->SetText(Directory + FileMask);
     QueueCheck->SetChecked(Params->GetQueue());
     QueueNoConfirmationCheck->SetChecked(Params->GetQueueNoConfirmation());

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -4202,7 +4202,7 @@ void TWinSCPFileSystem::MultipleEdit(const UnicodeString & Directory,
   else
   {
     UnicodeString TempDir;
-    TGUICopyParamType &CopyParam = GetGUIConfiguration()->GetDefaultCopyParam();
+    TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
     EditViewCopyParam(CopyParam);
 
     std::unique_ptr<TStrings> FileList(std::make_unique<TStringList>());

--- a/src/base/Common.cpp
+++ b/src/base/Common.cpp
@@ -1364,6 +1364,7 @@ UnicodeString ValidLocalFileName(
       }
     }
 
+#if defined(__BORLANDC__)
     // Windows trim trailing space or dot, hence we must encode it to preserve it
     if (!FileName.IsEmpty() &&
         ((FileName[FileName.Length()] == L' ') ||
@@ -1381,6 +1382,7 @@ UnicodeString ValidLocalFileName(
       }
       FileName.Insert(L"%00", P);
     }
+#endif // defined(__BORLANDC__)
   }
   return FileName;
 }
@@ -1941,7 +1943,8 @@ UnicodeString MakeUnicodeLargePath(const UnicodeString & APath)
 
 UnicodeString ApiPath(const UnicodeString & APath)
 {
-  UnicodeString Path = APath;
+  // Convert "/" to "\" as we're returning NT-style path
+  UnicodeString Path = base::FromUnixPath(APath);
 
   const UnicodeString Drive = ExtractFileDrive(Path);
   // This may match even a path like "C:" or "\\server\\share", but we do not really care
@@ -1949,17 +1952,8 @@ UnicodeString ApiPath(const UnicodeString & APath)
   {
     Path = ExpandFileName(Path);
   }
-
-  // Max path for directories is 12 characters shorter than max path for files
-  if (Path.Length() >= (MAX_PATH - 12))
-  {
-    /*if (GetConfiguration() != nullptr)
-    {
-      GetConfiguration()->Usage->Inc(L"LongPath");
-    }*/
-    Path = MakeUnicodeLargePath(Path);
-  }
-  return Path;
+  // Return NT-style path unconditionally
+  return MakeUnicodeLargePath(Path);
 }
 
 UnicodeString DisplayableStr(const RawByteString & Str)

--- a/src/core/CopyParam.cpp
+++ b/src/core/CopyParam.cpp
@@ -47,7 +47,7 @@ void TCopyParamType::Default()
   SetInvalidCharsReplacement(TokenReplacement);
   SetLocalInvalidChars(::LocalInvalidChars);
   SetCalculateSize(true);
-  SetFileMask(AnyMask);
+  SetFileMask(L"");
   GetIncludeFileMask().Masks("");
   SetTransferSkipList(nullptr);
   SetTransferResumeFile("");


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/422)

To relax file naming restrictions it makes several fixes:

- Use NT-style names internally
- Remove restrictions on reserved names (`CON`, `PRN`, `AUX`, `COM1`, ...) and on trailing dot or space, since they don't apply to NT-style names

Also this pull request doesn't use the default file mask `*.*` (for multiple files) or a file name (for a single file) in Copy / Move dialogs (`copy to` / `move to` edit box) to be similar to `Far` Copy / Move dialogs. Moreover, some file names may conflict with file masks (in case of a single file copy or move), preventing the original file name from being used. An example: `abc.txt.` will be copied to the local system as `abc.txt`.