### PR TITLE
Fix Alt-F12 history navigation

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -440,7 +440,7 @@ void TWinSCPFileSystem::GetOpenPanelInfoEx(OPENPANELINFO_FLAGS & Flags,
   }
   else
   {
-    CurDir = FSessionsFolder;
+    CurDir = ROOTDIRECTORY + FSessionsFolder;
     AFormat = "netbox";
     Flags = !OPIF_DISABLESORTGROUPS | !OPIF_DISABLEHIGHLIGHTING | OPIF_USEATTRHIGHLIGHTING |
       OPIF_ADDDOTS | OPIF_SHOWPRESERVECASE | OPIF_SHORTCUT;

--- a/src/NetBox/WinSCPPlugin.cpp
+++ b/src/NetBox/WinSCPPlugin.cpp
@@ -324,11 +324,16 @@ TCustomFarFileSystem * TWinSCPPlugin::OpenPluginEx(OPENFROM OpenFrom, intptr_t I
         // DEBUG_PRINTF("Directory: %s", Directory);
         // DEBUG_PRINTF("CommandLine: %s", CommandLine);
 
+        UnicodeString SessionName(CommandLine);
+        if (SessionName.SubString(1, 7).LowerCase() == L"netbox:")
+        {
+          SessionName.Delete(1, 7);
+        }
         const bool Another = !(Flags & FOSF_ACTIVE);
         TWinSCPFileSystem * PanelSystem = rtti::dyn_cast_or_null<TWinSCPFileSystem>(GetPanelFileSystem());
 
         if (PanelSystem && PanelSystem->Connected() &&
-          PanelSystem->GetTerminal()->GetSessionData()->GenerateSessionUrl(sufComplete) == CommandLine)
+          PanelSystem->GetTerminal()->GetSessionData()->GetSessionName() == SessionName)
         {
           PanelSystem->SetDirectoryEx(Directory, OPM_SILENT);
           if (PanelSystem->UpdatePanel(false, Another))


### PR DESCRIPTION
The pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/439).

It introduces two fixes:

- Fix history navigation inside the connected session. This prevents an already open session from being reopened (if not needed) when using `Alt-F12` history menu
- Fix history navigation in the session list itself. This allows `Far` to correctly select folders inside the session list when the user is already there

The latter fix uses *history entries* like `netbox:/some/session/list/folder` instead of `netbox:some/session/list/folder` to help `Far` and `Netbox` do the job correctly.