### PR TITLE
Fix editor not taking transfer settings into account

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -2724,8 +2724,7 @@ int32_t TWinSCPFileSystem::UploadFiles(bool Move, OPERATION_MODES OpMode, bool E
   bool Confirmed = (OpMode & OPM_SILENT);
   bool Ask = !Confirmed;
 
-  TGUICopyParamType CopyParam;
-  CopyParam.Default();
+  TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
 
   if (Edit)
   {
@@ -4225,6 +4224,7 @@ void TWinSCPFileSystem::MultipleEdit(const UnicodeString & Directory,
     UnicodeString TempDir;
     TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
     EditViewCopyParam(CopyParam);
+    FLastEditCopyParam = CopyParam;
 
     std::unique_ptr<TStrings> FileList(std::make_unique<TStringList>());
     DebugAssert(!FNoProgressFinish);

--- a/src/core/SftpFileSystem.cpp
+++ b/src/core/SftpFileSystem.cpp
@@ -2588,7 +2588,6 @@ SSH_FX_TYPE TSFTPFileSystem::GotStatusPacket(
       // and I believe I've seen one more server doing the same.
       if (Packet->GetRemainingLength() > 0)
       {
-        ServerMessage = Packet->GetString(FUtfStrings);
         LanguageTag = Packet->GetAnsiString();
         if ((FVersion >= 5) && (Message == SFTP_STATUS_UNKNOWN_PRINCIPAL))
         {


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/324)

It contains the following fixes:

- Take transfer settings into account when using editor
- Fix SFTP error decoding