### PR TITLE
Fix hotkey problems

### DIFF
--- a/src/NetBox/FarDialog.cpp
+++ b/src/NetBox/FarDialog.cpp
@@ -674,7 +674,7 @@ bool TFarDialog::HotKey(uint32_t Key, uint32_t ControlState) const
 {
   bool Result = false;
   char HotKey = 0;
-  if ((ControlState & ALTMASK) &&
+  if (CheckControlMaskSet(ControlState, ALTMASK) &&
     ('A' <= Key) && (Key <= 'Z'))
   {
     Result = true;

--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -2269,7 +2269,8 @@ TFarPanelInfo ** TCustomFarFileSystem::GetPanelInfo(int32_t Another)
     {
       DebugAssert(false);
     }
-    FPanelInfo[bAnother] = new TFarPanelInfo(Info, !bAnother ? this : nullptr);
+    const bool SetOwner = !bAnother || (GetOppositeFileSystem() == this);
+    FPanelInfo[bAnother] = new TFarPanelInfo(Info, SetOwner ? this : nullptr);
   }
   return &FPanelInfo[bAnother];
 }

--- a/src/NetBox/FarPlugin.h
+++ b/src/NetBox/FarPlugin.h
@@ -18,6 +18,15 @@ constexpr const DWORD CTRLMASK = (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED);
 constexpr const DWORD SHIFTMASK = (SHIFT_PRESSED);
 constexpr const wchar_t * SHORTCUT_DELIMITER = L"\1";
 
+template<typename... TMasks>
+bool CheckControlMaskSet(DWORD State, TMasks... Masks)
+{
+  const auto CtlState = State & RMASK;
+  // 1) check all individual masks are present in the ctl state
+  // 2) check all bits that are not in any mask are cleared 
+  return ((CtlState & Masks) && ...) && !(CtlState & ~(Masks | ...));
+}
+
 class TCustomFarFileSystem;
 class TFarPanelModes;
 class TFarKeyBarTitles;

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -247,8 +247,8 @@ bool TTabbedDialog::Key(TFarDialogItem * /*Item*/, intptr_t KeyCode)
   bool Result = false;
   const WORD Key = KeyCode & 0xFFFF;
   const WORD ControlState = nb::ToWord(KeyCode >> 16);
-  if ((((Key == VK_NEXT) || (Key == VK_NUMPAD3)) && (ControlState & CTRLMASK) != 0) ||
-    (((Key == VK_PRIOR) || (Key == VK_NUMPAD9)) && (ControlState & CTRLMASK) != 0))
+  if ((((Key == VK_NEXT) || (Key == VK_NUMPAD3)) && CheckControlMaskSet(ControlState, CTRLMASK)) ||
+    (((Key == VK_PRIOR) || (Key == VK_NUMPAD9)) && CheckControlMaskSet(ControlState, CTRLMASK)))
   {
     int32_t NewTab = FTab;
     do
@@ -7875,10 +7875,10 @@ bool TSynchronizeChecklistDialog::Key(TFarDialogItem * Item, intptr_t KeyCode)
   const WORD ControlState = nb::ToWord(KeyCode >> 16);
   if (ListBox->Focused())
   {
-    if (((Key == VK_ADD) && (ControlState & SHIFTMASK) != 0) ||
-      ((Key == VK_SUBTRACT) && (ControlState & SHIFTMASK) != 0))
+    if (((Key == VK_ADD) && CheckControlMaskSet(ControlState, SHIFTMASK)) ||
+      ((Key == VK_SUBTRACT) && CheckControlMaskSet(ControlState, SHIFTMASK)))
     {
-      CheckAll((Key == VK_ADD) && (ControlState & SHIFTMASK) != 0);
+      CheckAll((Key == VK_ADD) && CheckControlMaskSet(ControlState, SHIFTMASK));
       Result = true;
     }
     else if ((Key == VK_SPACE) || (Key == VK_INSERT) ||
@@ -7907,7 +7907,7 @@ bool TSynchronizeChecklistDialog::Key(TFarDialogItem * Item, intptr_t KeyCode)
       }
       Result = true;
     }
-    else if ((Key == VK_LEFT) && (ControlState & ALTMASK) != 0)
+    else if ((Key == VK_LEFT) && CheckControlMaskSet(ControlState, ALTMASK))
     {
       if (FScroll > 0)
       {
@@ -8642,7 +8642,7 @@ bool TQueueDialog::Key(TFarDialogItem * /*Item*/, intptr_t KeyCode)
       }
       Result = true;
     }
-    else if ((Key == VK_UP) && (ControlState & CTRLMASK) != 0)
+    else if ((Key == VK_UP) && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       if (MoveUpButton->GetEnabled())
       {
@@ -8650,7 +8650,7 @@ bool TQueueDialog::Key(TFarDialogItem * /*Item*/, intptr_t KeyCode)
       }
       Result = true;
     }
-    else if ((Key == VK_DOWN) && (ControlState & CTRLMASK) != 0)
+    else if ((Key == VK_DOWN) && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       if (MoveDownButton->GetEnabled())
       {

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -7518,7 +7518,7 @@ void TSynchronizeChecklistDialog::AddColumn(UnicodeString & List,
       Width--;
     }
     List += Value.SubString(Scroll + 1, Width);
-    if (!Header && (Len - Scroll > Width))
+    if (!AHeader && (Len - Scroll > Width))
     {
       List += L'}';
       FCanScrollRight = true;
@@ -7916,7 +7916,7 @@ bool TSynchronizeChecklistDialog::Key(TFarDialogItem * Item, intptr_t KeyCode)
       }
       Result = true;
     }
-    else if (Key == VK_RIGHT)
+    else if ((Key == VK_RIGHT) && CheckControlMaskSet(ControlState, ALTMASK))
     {
       if (FCanScrollRight)
       {

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -984,7 +984,7 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
   }
   else if (Connected())
   {
-    if ((Key == 'F') && CheckControlMaskSet(ControlState, CTRLMASK))
+    if ((Key == 'F') && CheckControlMaskSet(ControlState, CTRLMASK, ALTMASK))
     {
       InsertFileNameOnCommandLine(true);
       Handled = true;

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -1932,7 +1932,7 @@ void TWinSCPFileSystem::InsertTokenOnCommandLine(const UnicodeString & Token, bo
 
 void TWinSCPFileSystem::InsertSessionNameOnCommandLine()
 {
-  TFarPanelInfo * const * PanelInfo = GetPanelInfo();
+  TFarPanelInfo * const * PanelInfo = IsActiveFileSystem() ? GetPanelInfo(): GetAnotherPanelInfo();
   const TFarPanelItem * Focused = PanelInfo && *PanelInfo ? (*PanelInfo)->GetFocusedItem() : nullptr;
 
   if (Focused != nullptr)
@@ -1957,7 +1957,7 @@ void TWinSCPFileSystem::InsertSessionNameOnCommandLine()
 
 void TWinSCPFileSystem::InsertFileNameOnCommandLine(bool Full)
 {
-  TFarPanelInfo * const * PanelInfo = GetPanelInfo();
+  TFarPanelInfo * const * PanelInfo = IsActiveFileSystem() ? GetPanelInfo(): GetAnotherPanelInfo();
   const TFarPanelItem * Focused = PanelInfo && *PanelInfo ? (*PanelInfo)->GetFocusedItem() : nullptr;
 
   if (Focused != nullptr)

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -4113,8 +4113,8 @@ void TWinSCPFileSystem::MultipleEdit()
   }
 }
 
-void TWinSCPFileSystem::MultipleEdit(const UnicodeString & Directory,
-  const UnicodeString & AFileName, const TRemoteFile * AFile)
+void TWinSCPFileSystem::MultipleEdit(const UnicodeString Directory,
+  const UnicodeString AFileName, const TRemoteFile * AFile)
 {
   DebugAssert(AFile);
   TEditHistory EditHistory;

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -1025,8 +1025,7 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
       Handled = true;
     }
 
-    if ((Key == VK_INSERT) && (CheckControlMaskSet(ControlState, ALTMASK, SHIFTMASK) ||
-      CheckControlMaskSet(ControlState, CTRLMASK, ALTMASK)))
+    if ((Key == VK_INSERT) && CheckControlMaskSet(ControlState, ALTMASK, SHIFTMASK))
     {
       CopyFullFileNamesToClipboard();
       Handled = true;

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -916,8 +916,7 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
   TFarPanelInfo * const * PanelInfo = GetPanelInfo();
   const TFarPanelItem * Focused = PanelInfo && *PanelInfo ? (*PanelInfo)->GetFocusedItem() : nullptr;
 
-  if ((Key == 'W') && (ControlState & SHIFTMASK) &&
-    (ControlState & ALTMASK))
+  if ((Key == 'W') && CheckControlMaskSet(ControlState, SHIFTMASK, ALTMASK))
   {
     GetWinSCPPlugin()->CommandsMenu(true);
     Handled = true;
@@ -930,13 +929,13 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
       Data = cast_to<TSessionData>(ToObj(Focused->GetUserData()));
     }
 
-    if ((Key == 'F') && (ControlState & CTRLMASK))
+    if ((Key == 'F') && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       InsertSessionNameOnCommandLine();
       Handled = true;
     }
 
-    if ((Key == VK_RETURN) && (ControlState & CTRLMASK))
+    if ((Key == VK_RETURN) && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       InsertSessionNameOnCommandLine();
       Handled = true;
@@ -957,14 +956,14 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
       Handled = true;
     }
 
-    if (Key == VK_F4 && (ControlState & SHIFTMASK))
+    if (Key == VK_F4 && CheckControlMaskSet(ControlState, SHIFTMASK))
     {
       EditConnectSession(nullptr, true);
       Handled = true;
     }
 
     if (((Key == VK_F5) || (Key == VK_F6)) &&
-      (ControlState & SHIFTMASK))
+      CheckControlMaskSet(ControlState, SHIFTMASK))
     {
       if (Data != nullptr)
       {
@@ -973,7 +972,7 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
       Handled = true;
     }
 
-    if (Key == 'R' && (ControlState & CTRLMASK))
+    if (Key == 'R' && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       DeleteStoredSessions();
       if (UpdatePanel())
@@ -985,78 +984,75 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
   }
   else if (Connected())
   {
-    if ((Key == 'F') && (ControlState & CTRLMASK))
+    if ((Key == 'F') && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       InsertFileNameOnCommandLine(true);
       Handled = true;
     }
 
-    if ((Key == VK_RETURN) && (ControlState & CTRLMASK))
+    if ((Key == VK_RETURN) && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       InsertFileNameOnCommandLine(false);
       Handled = true;
     }
 
-    if ((Key == 'R') && (ControlState & CTRLMASK))
+    if ((Key == 'R') && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       FReloadDirectory = true;
     }
 
-    if ((Key == 'A') && (ControlState & CTRLMASK))
+    if ((Key == 'A') && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       FileProperties();
       Handled = true;
     }
 
-    if ((Key == 'G') && (ControlState & CTRLMASK))
+    if ((Key == 'G') && CheckControlMaskSet(ControlState, CTRLMASK))
     {
       ApplyCommand();
       Handled = true;
     }
 
-    if ((Key == 'Q') && (ControlState & SHIFTMASK) &&
-      (ControlState & ALTMASK))
+    if ((Key == 'Q') && CheckControlMaskSet(ControlState, SHIFTMASK, ALTMASK))
     {
       QueueShow(false);
       Handled = true;
     }
 
-    if ((Key == 'B') && (ControlState & CTRLMASK) &&
-      (ControlState & ALTMASK))
+    if ((Key == 'B') && CheckControlMaskSet(ControlState, CTRLMASK, ALTMASK))
     {
       ToggleSynchronizeBrowsing();
       Handled = true;
     }
 
-    if ((Key == VK_INSERT) && (((ControlState & ALTMASK) && (ControlState & SHIFTMASK)) ||
-        (((ControlState & CTRLMASK) && (ControlState & ALTMASK)))))
+    if ((Key == VK_INSERT) && (CheckControlMaskSet(ControlState, ALTMASK, SHIFTMASK) ||
+      CheckControlMaskSet(ControlState, CTRLMASK, ALTMASK)))
     {
       CopyFullFileNamesToClipboard();
       Handled = true;
     }
 
-    if ((Key == VK_F6) && (ControlState & ALTMASK) && !(ControlState & SHIFTMASK))
+    if ((Key == VK_F6) && CheckControlMaskSet(ControlState, ALTMASK))
     {
       RemoteCreateLink();
       Handled = true;
     }
 
     if (Focused && ((Key == VK_F5) || (Key == VK_F6)) &&
-      (ControlState & SHIFTMASK) && !(ControlState & ALTMASK))
+      CheckControlMaskSet(ControlState, SHIFTMASK))
     {
       TransferFiles((Key == VK_F6));
       Handled = true;
     }
 
     if (Focused && (Key == VK_F6) &&
-      ((ControlState & SHIFTMASK) && (ControlState & ALTMASK)))
+      CheckControlMaskSet(ControlState, SHIFTMASK, ALTMASK))
     {
       RenameFile();
       Handled = true;
     }
 
-    if ((Key == VK_F12) && (ControlState & SHIFTMASK) &&
-      (ControlState & ALTMASK))
+    if ((Key == VK_F12) && CheckControlMaskSet(ControlState, SHIFTMASK, ALTMASK))
     {
       OpenDirectory(false);
       Handled = true;
@@ -1071,8 +1067,8 @@ bool TWinSCPFileSystem::ProcessKeyEx(int32_t Key, uint32_t ControlState)
 
     // Return to session panel
     if (Focused && !Handled && !IsConnectedDirectly() && 
-         ((Key == VK_RETURN) && (Focused->GetFileName() == PARENTDIRECTORY) ||
-         (Key == VK_PRIOR) && (ControlState & CTRLMASK)) && FLastPath == ROOTDIRECTORY)
+         ((Key == VK_RETURN) && (ControlState == 0) && (Focused->GetFileName() == PARENTDIRECTORY) ||
+         (Key == VK_PRIOR) && CheckControlMaskSet(ControlState, CTRLMASK)) && FLastPath == ROOTDIRECTORY)
     {
       SetDirectoryEx(PARENTDIRECTORY, 0);
       if (UpdatePanel())

--- a/src/NetBox/WinSCPFileSystem.h
+++ b/src/NetBox/WinSCPFileSystem.h
@@ -215,7 +215,7 @@ protected:
       const UnicodeString & RealFileName, UnicodeString & DestPath);
   void LogAuthentication(TTerminal * Terminal, const UnicodeString & Msg);
   void MultipleEdit();
-  void MultipleEdit(const UnicodeString & Directory, const UnicodeString & AFileName, const TRemoteFile * AFile);
+  void MultipleEdit(const UnicodeString Directory, const UnicodeString AFileName, const TRemoteFile * AFile);
   void EditViewCopyParam(TCopyParamType & CopyParam);
   bool SynchronizeBrowsing(const UnicodeString & NewPath);
   bool IsEditHistoryEmpty() const;

--- a/src/NetBox/WinSCPPlugin.cpp
+++ b/src/NetBox/WinSCPPlugin.cpp
@@ -263,8 +263,7 @@ int32_t TWinSCPPlugin::ProcessEditorInputEx(const INPUT_RECORD * Rec)
   if ((Rec->EventType == KEY_EVENT) &&
     Rec->Event.KeyEvent.bKeyDown &&
     (Rec->Event.KeyEvent.uChar.AsciiChar == 'W') &&
-    (FLAGSET(Rec->Event.KeyEvent.dwControlKeyState, ALTMASK)) &&
-    (FLAGSET(Rec->Event.KeyEvent.dwControlKeyState, SHIFTMASK)))
+    CheckControlMaskSet(Rec->Event.KeyEvent.dwControlKeyState, ALTMASK, SHIFTMASK))
   {
     CommandsMenu(false);
     Result = 1;

--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -9634,9 +9634,8 @@ void TLocalFileHandle::Close()
 UnicodeString GetSessionUrl(const TTerminal * Terminal, bool WithUserName)
 {
   UnicodeString Result;
-  const TSessionInfo & SessionInfo = Terminal->GetSessionInfo();
   const TSessionData * SessionData = Terminal->GetSessionData();
-  UnicodeString Protocol = SessionInfo.ProtocolBaseName;
+  UnicodeString Protocol = SessionData->FSProtocolStr;
   const UnicodeString HostName = SessionData->GetHostNameExpanded();
   const UnicodeString UserName = SessionData->GetUserNameExpanded();
   const int32_t Port = Terminal->GetSessionData()->GetPortNumber();


### PR DESCRIPTION
This pull request fixes many problems regarding hotkeys. Summary of the fixed problems:

1. Many hotkeys processed by the plugin are ambiguous due to inconsistent checks. For example, `Ctrl-G` (Apply command) can also be processed as `Ctrl-Alt-G` or `Ctrl-Shift-G`.
2. *Insert full file name* action (bound to `Ctrl-F` hotkey) inserts full file name as a "session url" like `ssh://user@localhost:22/tmp/abc.txt` which is not actually the *full file name*. Several issues were created to argue with such a behaviour. This pull request provides a better alternative - release `Ctrl-F` hotkey and bind the action to `Ctrl-Alt-F`.
3. Aforementioned *insert full file name* action inserts empty prefixes for all protocols except `scp / sftp`.
4. A hotkey `Ctrl-;` (`Ctrl-Alt-;`) shows incorrect results and may lead to a crash.
5. `NetBox` binds two hotkeys to one action (`Ctrl-Alt-Ins`, `Alt-Shift-Ins`) not allowing Far to provide a different alternative action. It's better to keep only one hotkey (`Alt-Shift-Ins`), thereby allowing users to use both actions.
6. Unable to show command menu (`Alt-Shift-W`) when editing a file.
7. Edit history selects the wrong file (multiedit mode is on).
8. Synchronize checklist misses `Alt` modifier in `Alt-Right` hotkey (horizontal scrolling), also horizontal scrolling is not working.

Pos. 2 mention this issues: [1](https://github.com/michaellukashov/Far-NetBox/issues/326) and [2](https://github.com/michaellukashov/Far-NetBox/issues/162)
