### PR TITLE
Fix WebDAV preserve time

### DIFF
--- a/src/base/Sysutils.cpp
+++ b/src/base/Sysutils.cpp
@@ -1377,6 +1377,15 @@ bool TryStrToDateTime(const UnicodeString & StrValue, TDateTime & Value,
 UnicodeString DateTimeToString(const UnicodeString & Format,
   const TDateTime & DateTime)
 {
+  auto LocaleDeleter = [](_locale_t *Locale)
+  {
+    if (Locale && *Locale)
+    {
+      _free_locale(*Locale);
+    }
+  };
+  static std::unique_ptr<_locale_t, decltype(LocaleDeleter)> CLocale(new _locale_t(_create_locale(LC_TIME, "C")), LocaleDeleter);
+
   UnicodeString Result;
   // SYSTEMTIME st;
   // ::ZeroMemory(&st, sizeof(SYSTEMTIME));
@@ -1402,7 +1411,7 @@ UnicodeString DateTimeToString(const UnicodeString & Format,
     return Result;
 
   AnsiString Buffer(80, 0);
-  if (0 != strftime(const_cast<char *>(Buffer.data()), Buffer.GetLength(), AnsiString(Format).c_str(), &dt))
+  if (0 != _strftime_l(const_cast<char *>(Buffer.data()), Buffer.GetLength(), AnsiString(Format).c_str(), &dt, *CLocale))
     Result = Buffer;
 
   return Result;

--- a/src/base/Sysutils.cpp
+++ b/src/base/Sysutils.cpp
@@ -1402,7 +1402,7 @@ UnicodeString DateTimeToString(const UnicodeString & Format,
     return Result;
 
   AnsiString Buffer(80, 0);
-  if (0 != strftime(const_cast<char *>(Buffer.data()), sizeof(Buffer), AnsiString(Format).c_str(), &dt))
+  if (0 != strftime(const_cast<char *>(Buffer.data()), Buffer.GetLength(), AnsiString(Format).c_str(), &dt))
     Result = Buffer;
 
   return Result;

--- a/src/core/WebDAVFileSystem.cpp
+++ b/src/core/WebDAVFileSystem.cpp
@@ -1428,11 +1428,7 @@ void TWebDAVFileSystem::Source(
         UnicodeString LastModified =
           FormatDateTime(L"ddd, d mmm yyyy hh:nn:ss 'GMT'", ModificationUTC, FormatSettings);
 #endif // defined(__BORLANDC__)
-        uint16_t Y, M, D, H, NN, S, MS;
-        const TDateTime & DateTime = ModificationUTC;
-        DateTime.DecodeDate(Y, M, D);
-        DateTime.DecodeTime(H, NN, S, MS);
-        const UnicodeString LastModified = FORMAT("%04d, %d %02d %04d %02d:%02d%02d 'GMT'", D, D, M, Y, H, NN, D);
+        const UnicodeString LastModified = DateTimeToString(L"%a, %#d %b %Y %H:%M:%S GMT", ModificationUTC);
 
         const UTF8String NeonLastModified(LastModified);
         // second element is "NULL-terminating"


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/261)

P.S. Anyway, most WebDAV servers do not allow to change modification time through `getlastmodified`.