### PR TITLE
Fix properties implementation

### DIFF
--- a/src/base/FileBuffer.h
+++ b/src/base/FileBuffer.h
@@ -56,7 +56,7 @@ public:
   char * GetPointer() const { return GetData() + GetPosition(); }
   void NeedSpace(int64_t Size);
   void SetSize(int64_t Value);
-  int64_t GetPosition() const { return nb::ToInt64(FMemory->Position); }
+  int64_t GetPosition() const { return FMemory->Position; }
   void ProcessRead(int64_t Len, DWORD Result);
 };
 

--- a/src/base/Property.hpp
+++ b/src/base/Property.hpp
@@ -23,10 +23,11 @@ public:
   {
     DebugCheck(!_getter.empty());
   }
-  ROProperty(const ROProperty &) = default;
-  ROProperty(ROProperty &&) noexcept = default;
-  ROProperty & operator =(const ROProperty &) = default;
-  ROProperty & operator =(ROProperty &&) noexcept = default;
+  ROProperty(const ROProperty &) = delete;
+  ROProperty(ROProperty &&) noexcept = delete;
+  ~ROProperty() = default;
+  ROProperty & operator =(const ROProperty &) = delete;
+  ROProperty & operator =(ROProperty &&) noexcept = delete;
 
   constexpr T operator()() const
   {
@@ -74,10 +75,11 @@ public:
   {
     DebugCheck(!_getter.empty());
   }
-  ROIndexedProperty(const ROIndexedProperty &) = default;
-  ROIndexedProperty(ROIndexedProperty &&) noexcept = default;
-  ROIndexedProperty & operator =(const ROIndexedProperty &) = default;
-  ROIndexedProperty & operator =(ROIndexedProperty &&) noexcept = default;
+  ROIndexedProperty(const ROIndexedProperty &) = delete;
+  ROIndexedProperty(ROIndexedProperty &&) noexcept = delete;
+  ~ROIndexedProperty() = default;
+  ROIndexedProperty & operator =(const ROIndexedProperty &) = delete;
+  ROIndexedProperty & operator =(ROIndexedProperty &&) noexcept = delete;
   constexpr T operator [](int32_t Index) const
   {
     DebugCheck(_getter);
@@ -98,10 +100,11 @@ public:
   {
     DebugCheck(_value != nullptr);
   }
-  ROProperty2(const ROProperty2 &) = default;
-  ROProperty2(ROProperty2 &&) noexcept = default;
-  ROProperty2 & operator =(const ROProperty2 &) = default;
-  ROProperty2 & operator =(ROProperty2 &&) noexcept = default;
+  ROProperty2(const ROProperty2 &) = delete;
+  ROProperty2(ROProperty2 &&) noexcept = delete;
+  ~ROProperty2() = default;
+  ROProperty2 & operator =(const ROProperty2 &) = delete;
+  ROProperty2 & operator =(ROProperty2 &&) noexcept = delete;
 
   constexpr T operator ()() const
   {
@@ -162,10 +165,16 @@ public:
   {
     DebugCheck(!_setter.empty());
   }
-  RWProperty(const RWProperty &) = default;
-  RWProperty(RWProperty &&) noexcept = default;
-  RWProperty & operator =(const RWProperty &) = default;
-  RWProperty & operator =(RWProperty &&) noexcept = default;
+  RWProperty(const RWProperty &) = delete;
+  RWProperty(RWProperty &&) noexcept = delete;
+  ~RWProperty() = default;
+  RWProperty & operator =(const RWProperty & Value)
+  {
+    DebugCheck(_setter);
+    _setter(Value());
+    return *this;
+  }
+  RWProperty & operator =(RWProperty &&) noexcept = delete;
 
   using ROProperty<T>::operator();
   void operator()(ValueType Value)
@@ -196,10 +205,16 @@ public:
   {
     DebugCheck(_value != nullptr);
   }
-  RWProperty2(const RWProperty2 &) = default;
-  RWProperty2(RWProperty2 &&) noexcept = default;
-  RWProperty2 & operator =(const RWProperty2 &) = default;
-  RWProperty2 & operator =(RWProperty2 &&) noexcept = default;
+  RWProperty2(const RWProperty2 &) = delete;
+  RWProperty2(RWProperty2 &&) noexcept = delete;
+  ~RWProperty2() = default;
+  RWProperty2 & operator =(const RWProperty2 & Value)
+  {
+    DebugCheck(_value);
+    *_value = Value();
+    return *this;
+  }
+  RWProperty2 & operator =(RWProperty2 &&) noexcept = delete;
 
   constexpr T operator ()() const
   {
@@ -216,7 +231,7 @@ public:
   constexpr T operator ->() const
   {
     DebugCheck(_value);
-    return _value();
+    return *_value;
   }
 
   constexpr T operator ->()
@@ -271,10 +286,16 @@ public:
     DebugCheck(_value != nullptr);
     DebugCheck(!_setter.empty());
   }
-  RWPropertySimple(const RWPropertySimple &) = default;
-  RWPropertySimple(RWPropertySimple &&) noexcept = default;
-  RWPropertySimple & operator =(const RWPropertySimple &) = default;
-  RWPropertySimple & operator =(RWPropertySimple &&) noexcept = default;
+  RWPropertySimple(const RWPropertySimple &) = delete;
+  RWPropertySimple(RWPropertySimple &&) noexcept = delete;
+  ~RWPropertySimple() = default;
+  RWPropertySimple & operator =(const RWPropertySimple & Value)
+  {
+    DebugCheck(_setter);
+    _setter(Value());
+    return *this;
+  }
+  RWPropertySimple & operator =(RWPropertySimple &&) noexcept = delete;
   constexpr T operator ()() const
   {
     DebugCheck(_value);
@@ -288,7 +309,7 @@ public:
   constexpr T operator ->() const
   {
     DebugCheck(_value);
-    return _value();
+    return *_value;
   }
   constexpr T operator ->()
   {

--- a/src/core/SessionInfo.cpp
+++ b/src/core/SessionInfo.cpp
@@ -1349,7 +1349,7 @@ void TSessionLog::DoAddStartupInfo(TSessionData * Data)
       }
       else
       {
-        PingType = EnumName(Data->PingType, PingTypeNames);
+        PingType = EnumName(Data->PingType(), PingTypeNames);
         PingInterval = Data->PingInterval;
       }
       ADF("Ping type: %s, Ping interval: %d sec; Timeout: %d sec",


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/450)

Under the hood, this pull request fixes how properties are implemented. Consider the following code, that contain assignment of one property to another:

```c++
FCommandSession->CurrentDirectory = CurrentDirectory;
```

This assignment is embarassing, because it doesn't do what it's supposed to do. So, the current implementation of the properties is slightly different from the C++ Builder semantics. We need to disable copy / move constructors - we don't want properties to be copied / moved. We also need to disable copy / move operators on RO properties, and disable move operator on RW properties. We should use explicit copy operator for RW properties with correct semantics, i.e. copy values instead of copying setters and getters.