### PR TITLE
Fix broken terminal output

### DIFF
--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -1271,6 +1271,10 @@ int32_t TCustomFarPlugin::Message(uint32_t Flags,
       nullptr,
       static_cast<const wchar_t * const *>(static_cast<const void *>(Items.c_str())), 0, 0));
   }
+  if (FTerminalScreenShowing)
+  {
+    FarControl(FCTL_GETUSERSCREEN, 0, nullptr);
+  }
   return Result;
 }
 
@@ -1560,55 +1564,8 @@ void TCustomFarPlugin::ScrollTerminalScreen(int32_t Rows)
 void TCustomFarPlugin::ShowTerminalScreen(const UnicodeString & Command)
 {
   DebugAssert(!FTerminalScreenShowing);
-  TPoint Size, Cursor;
-  TerminalInfo(&Size, &Cursor);
-
-  if (Size.y >= 2)
-  {
-    // clean menu keybar area before command output
-    int32_t Y = Size.y - 2;
-    // if any panel is visible -- clear all screen (don't scroll panel)
-    {
-      PanelInfo Info{};
-      nb::ClearStruct(Info);
-      Info.StructSize = sizeof(Info);
-      FarControl(FCTL_GETPANELINFO, 0, &Info, PANEL_ACTIVE);
-      if (Info.Flags & PFLAGS_VISIBLE)
-      {
-        Y = 0;
-      }
-      else
-      {
-        nb::ClearStruct(Info);
-        Info.StructSize = sizeof(Info);
-        FarControl(FCTL_GETPANELINFO, 0, &Info, PANEL_PASSIVE);
-        if (Info.Flags & PFLAGS_VISIBLE)
-        {
-          Y = 0;
-        }
-      }
-    }
-    UnicodeString Blank = ::StringOfChar(L' ', Size.x);
-    do
-    {
-      Text(0, Y, 7 /*LIGHTGRAY*/, Blank);
-    } while (++Y < Size.y);
-    if (Command.Length() && Size.x > 2)
-    {
-      Blank = Command;
-      Blank.Insert(0, L"$ ", 2);
-      if (Blank.Length() > Size.x) Blank.SetLength(Size.x);
-      if (Cursor.y == Y-1) --Cursor.y; // !'Show key bar'
-      Text(0, Cursor.y, 7 /*LIGHTGRAY*/, Blank);
-      ++Cursor.y;
-    }
-  }
-  FlushText();
-
-  COORD Coord{};
-  Coord.X = 0;
-  Coord.Y = static_cast<SHORT>(Cursor.y);
-  ::SetConsoleCursorPosition(FConsoleOutput, Coord);
+  FarControl(FCTL_GETUSERSCREEN, 0, nullptr);
+  FarWriteConsole(L"$ " + Command + "\n");
   FTerminalScreenShowing = true;
 }
 


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/michaellukashov/Far-NetBox/issues/456).

There are a number of problems with terminal output:

- Terminal output is broken when a command is failed (`SCP`  commands)
- If panels are shown, then executing a command causes terminal to clear the previous output.  This is very annoying. `Far` does not clear terminal under the same conditions
- If `Far` is working with `ConEmu` console emulator in `BufferHeight mode ON`, then executing command is not showing: for example, if `pwd` is entered, then a line `$ pwd` is not shown.

This problems are fixed with this pull request.