### PR TITLE
Fix possible crashes on lost connections while modal dialog is shown

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -756,7 +756,10 @@ bool TWinSCPFileSystem::ProcessPanelEventEx(intptr_t Event, void * Param)
       // we must count on having ProcessPanelEvent(FE_IDLE) called again.
       try
       {
-        FTerminal->Idle();
+        if (GetPlugin()->FTopDialog == nullptr)
+        {
+          FTerminal->Idle();
+        }
       }
       catch (EConnectionFatal & E)
       {


### PR DESCRIPTION
When a modal dialog is shown and in that moment a connection becomes broken, a crash can happen.

There are a lot of examples. To reproduce one of them:

1. open `SCP` connection
2. press `F8`  on some file and see the confirmation dialog
3. simulate broken connection (e.g. kill `ssh` process, reconnect vpn, etc)
4. you'll see an error message about broken connection. Press `Abort`, then `Ok` or `Cancel`, and get the crash

This PR fixes this problem.