### PR TITLE
Fix freeze on exit

### DIFF
--- a/src/filezilla/FileZillaIntf.cpp
+++ b/src/filezilla/FileZillaIntf.cpp
@@ -64,8 +64,6 @@ void TFileZillaIntf::Finalize()
 #ifndef NO_IPV6
   if (wship6_module)
     ::FreeLibrary(wship6_module);
-  if (winsock2_module)
-    ::FreeLibrary(winsock2_module);
 #endif
   if (winsock_module)
     ::FreeLibrary(winsock_module);


### PR DESCRIPTION
At least on Windows 7 SP1 x86 there is a freeze when exiting Far (if `NetBox` was loaded). See [this post](https://forum.farmanager.com/viewtopic.php?p=177755#p177755)

This PR resolves this issue. It fixes double unloading of winsock library that leads to a memory corruption clearly visible on Windows 7 SP1 x86.