### PR TITLE
Fix dialog message

### DIFF
--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -1009,9 +1009,9 @@ void TFarMessageDialog::InitFarMessageDialog(uint32_t AFlags,
       ButtonLines++;
     }
 
-    if (MaxLen < Button->GetRight() - GetBorderBox()->GetLeft())
+    if (MaxLen < Button->GetRight() - GetBorderBox()->GetLeft() + 4)
     {
-      MaxLen = Button->GetRight() - GetBorderBox()->GetLeft() + 2;
+      MaxLen = Button->GetRight() - GetBorderBox()->GetLeft() + 4;
     }
 
     SetNextItemPosition(ipRight);
@@ -1023,9 +1023,9 @@ void TFarMessageDialog::InitFarMessageDialog(uint32_t AFlags,
     FCheckBox = MakeOwnedObject<TFarCheckBox>(this);
     FCheckBox->SetCaption(FParams->CheckBoxLabel);
 
-    if (MaxLen < FCheckBox->GetRight() - GetBorderBox()->GetLeft())
+    if (MaxLen < FCheckBox->GetRight() - GetBorderBox()->GetLeft() + 4)
     {
-      MaxLen = FCheckBox->GetRight() - GetBorderBox()->GetLeft();
+      MaxLen = FCheckBox->GetRight() - GetBorderBox()->GetLeft() + 4;
     }
   }
   else
@@ -1035,7 +1035,7 @@ void TFarMessageDialog::InitFarMessageDialog(uint32_t AFlags,
 
   const TRect rect = GetClientRect();
   TPoint S(
-    nb::ToInt32(rect.Left + MaxLen - rect.Right),
+    nb::ToInt32(rect.Left + MaxLen - (rect.Right + 1)),
     nb::ToInt32(rect.Top + MessageLines->GetCount() +
       (FParams->MoreMessages != nullptr ? 1 : 0) + ButtonLines +
       (!FParams->CheckBoxLabel.IsEmpty() ? 1 : 0) +

--- a/src/base/Sysutils.cpp
+++ b/src/base/Sysutils.cpp
@@ -702,6 +702,11 @@ UnicodeString WrapText(const UnicodeString & Line, int32_t MaxWidth)
     MaxWidth = 5;
   }
 
+  if (nb::StrLength(Line.c_str()) <= MaxWidth)
+  {
+    return Line;
+  }
+
   /* two passes through the input. the first pass updates the buffer length.
    * the second pass creates and populates the buffer
    */
@@ -752,14 +757,8 @@ UnicodeString WrapText(const UnicodeString & Line, int32_t MaxWidth)
       }
 
       /* copy as many words as will fit onto the current line */
-      while (S && *S && (nb::StrLength(S) + 1) <= SpaceLeft)
+      while (S && *S && nb::StrLength(S) <= SpaceLeft)
       {
-        if (Result.Length() == 0)
-        {
-          ++LenBuffer;
-        }
-        --SpaceLeft;
-
         /* then copy the word */
         while (*S)
         {
@@ -804,8 +803,6 @@ UnicodeString WrapText(const UnicodeString & Line, int32_t MaxWidth)
 
       ++LineCount;
     }
-
-    LenBuffer += 2;
 
     if (W)
     {


### PR DESCRIPTION
This PR fixes this issues:

* In function `UnicodeString WrapText(const UnicodeString & Line, int32_t MaxWidth)` the `MaxWidth` param is not max width, actual max width is **always** less than that.
* `DialogMessage` has edge cases when buttons go out of borders
* A long text line that should fit the whole client area width of `DialogMessage` has inconsistent spacing: 1 space on the left (correct) and 2 spaces on the right (should be 1 space): 
   `|| Long text  ||` - before fix
   `|| Long text ||` - after fix

An example of buttons going out of borders:
![before](https://github.com/michaellukashov/Far-NetBox/assets/79405160/d17db061-381b-40a0-aff8-2a0498ebf500)

An example of fixed dialog, that also shows correct spacing and text wrapping:
![after](https://github.com/michaellukashov/Far-NetBox/assets/79405160/87eab4e4-2291-4f26-8b99-9fef96112f61)

@michaellukashov, You should also fix `test1` function in the file `tests/testnetbox_02.cpp` in `far3-dev-tests` branch:
```c++
    REQUIRE_EQUAL(3, MessageLines.GetCount());
    REQUIRE_EQUAL(L"long long long long", MessageLines.GetString(0));
    REQUIRE_EQUAL("long long long long", W2MB(MessageLines.GetString(1).c_str()));
    REQUIRE_EQUAL("long text", W2MB(MessageLines.GetString(2).c_str()));
```
