### PR TITLE
Fix Charset encoding for filenames

### DIFF
--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -557,6 +557,8 @@ void TSessionData::NonPersistent()
   PROPERTY(FtpHost); \
   PROPERTY2(FtpWorkFromCwd); \
   PROPERTY2(FtpAnyCodeForPwd); \
+  PROPERTY2(CodePage); \
+  PROPERTY2(CodePageAsNumber); \
   PROPERTY(SslSessionReuse); \
   PROPERTY(TlsCertificateFile); \
   \

--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -645,10 +645,6 @@ void TSessionData::DoCopyData(const TSessionData * SourceData, bool NoRecrypt)
     SetKex(Index, DefaultKexList[Index]);
   }
 
-  FOverrideCachedHostKey = SourceData->GetOverrideCachedHostKey();
-  FModified = SourceData->GetModified();
-  FSaveOnly = SourceData->GetSaveOnly();
-
   FSource = SourceData->FSource;
   FNumberOfRetries = SourceData->FNumberOfRetries;
 }


### PR DESCRIPTION
`Charset encoding for filenames` on `Environment` tab of Session edit dialog is not working. You cannot actually change charset of filenames. This happend because `TSessionData::DoCopyData` does not copy `FCodePage` / `FCodePageAsNumber` fields.

This PR fixes aforementioned issue. It should also help solve [this external issue](https://forum.farmanager.com/viewtopic.php?p=177611#p177611).

Under the hood, this PR also removes duplicate code fragment that remained after routine update.