### PR TITLE
Fix MFC termination

### DIFF
--- a/src/filezilla/afxdll.cpp
+++ b/src/filezilla/afxdll.cpp
@@ -12,4 +12,9 @@ void InitExtensionModule(HINSTANCE HInstance)
 
 void TermExtensionModule()
 {
+  AfxTermLocalData(NULL, TRUE);
+  AfxCriticalTerm();
+
+  // Release the reference to Thread Local Storage data.
+  AfxTlsRelease();
 }


### PR DESCRIPTION
This pull request fixes Resource/Memory Leaks When Using MFC in a Static Library, see [Microsoft KB Archive/192102](https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/192102)
