### PR TITLE
Fix log time format

### DIFF
--- a/src/core/SessionInfo.cpp
+++ b/src/core/SessionInfo.cpp
@@ -881,9 +881,10 @@ void TSessionLog::DoAddToSelf(TLogLineType Type, const UnicodeString & ALine)
 
     if (FLogger != nullptr)
     {
+      const UTF8String UtfLine = UTF8String(UnicodeString(1, LogLineMarks[Type]) + " " + TrimRight(ALine)); // without timestamp
+#if defined(__BORLANDC__)
       const UnicodeString Timestamp = FormatDateTime(L" yyyy-mm-dd hh:nn:ss.zzz ", Now());
       const UTF8String UtfLine = UTF8String(UnicodeString(1, LogLineMarks[Type]) + Timestamp + TrimRight(ALine)); // + "\r\n";
-#if defined(__BORLANDC__)
       for (int32_t Index = 1; Index <= UtfLine.Length(); Index++)
       {
         if ((UtfLine[Index] == '\n') &&


### PR DESCRIPTION
This pull request fixes logging format. Currently it duplicates date and time, thus making logs too verbose, and taking up a lot of space.

So, instead of
`2024-04-12 16:01:07.665 . 2024-04-12 16:01:07.665 Looking for incoming data`

it produces more compact line:
`2024-04-12 16:01:07.665 . Looking for incoming data`
