### PR TITLE
Fix error when uploading an existing directory

### DIFF
--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -4104,12 +4104,12 @@ TRemoteFile * TTerminal::ReadFile(const UnicodeString & AFileName)
   return File.release();
 }
 
-TRemoteFile * TTerminal::TryReadFile(const UnicodeString & AFileName, bool AExceptionOnFail)
+TRemoteFile * TTerminal::TryReadFile(const UnicodeString & AFileName)
 {
   TRemoteFile * File;
   try
   {
-    SetExceptionOnFail(AExceptionOnFail);
+    SetExceptionOnFail(true);
     try__finally
     {
       File = ReadFile(base::UnixExcludeTrailingBackslash(AFileName));
@@ -7808,7 +7808,7 @@ void TTerminal::SourceRobust(
 bool TTerminal::CreateTargetDirectory(
   const UnicodeString & ADirectoryPath, uint32_t Attrs, const TCopyParamType * CopyParam)
 {
-  std::unique_ptr<TRemoteFile> File(TryReadFile(ADirectoryPath, false));
+  std::unique_ptr<TRemoteFile> File(TryReadFile(ADirectoryPath));
   const bool DoCreate =
     (File == nullptr) ||
     !File->IsDirectory; // just try to create and make it fail

--- a/src/core/Terminal.h
+++ b/src/core/Terminal.h
@@ -600,7 +600,7 @@ public:
   TRemoteFileList * CustomReadDirectoryListing(const UnicodeString & Directory, bool UseCache);
   TRemoteFile * ReadFileListing(const UnicodeString & APath);
   TRemoteFile * ReadFile(const UnicodeString & AFileName);
-  TRemoteFile * TryReadFile(const UnicodeString & AFileName, bool AExceptionOnFail = true);
+  TRemoteFile * TryReadFile(const UnicodeString & AFileName);
   bool FileExists(const UnicodeString & AFileName);
   void ReadSymlink(TRemoteFile * SymlinkFile, TRemoteFile *& AFile);
   bool CopyToLocal(


### PR DESCRIPTION
This pull request fixes #417 and fixes #470.

An error message is displayed in `SFTP` session when uploading an already existing directory to the remote: Error code 4 (Error creating folder).

This PR reverts commit `1ed9b3` in favour of commit `2d9d9d`. The latter one resolves all the issues.