### PR TITLE
Fix situations where some exception messages are not displayed

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -310,6 +310,8 @@ TWinSCPFileSystem::~TWinSCPFileSystem() noexcept
 
 void TWinSCPFileSystem::HandleException(Exception * E, OPERATION_MODES OpMode)
 {
+  bool DoClose = false;
+
   if ((GetTerminal() != nullptr) && rtti::isa<EFatal>(E))
   {
     const bool Reopen = GetTerminal()->QueryReopen(E, 0, nullptr);
@@ -319,17 +321,23 @@ void TWinSCPFileSystem::HandleException(Exception * E, OPERATION_MODES OpMode)
     }
     else
     {
-      if (GetTerminal())
-        GetTerminal()->ShowExtendedException(E);
-      if (!GetClosed())
-      {
-        ClosePanel();
-      }
+      GetTerminal()->ShowExtendedException(E);
+      DoClose = true;
     }
+  }
+  else if ((GetTerminal() != nullptr) && rtti::isa<EAbort>(E))
+  {
+    DoClose = true;
   }
   else
   {
     TCustomFarFileSystem::HandleException(E, OpMode);
+    return;
+  }
+
+  if (DoClose && !GetClosed())
+  {
+    ClosePanel();
   }
 }
 

--- a/src/base/Exceptions.cpp
+++ b/src/base/Exceptions.cpp
@@ -302,8 +302,9 @@ ExtException::ExtException(const Exception * E, const UnicodeString & Msg, const
 }
 
 ExtException::ExtException(TObjectClassId Kind, const Exception * E, int32_t Ident) :
-  Exception(Kind, E, Ident)
+  Exception(Kind, L"", Ident)
 {
+  AddMoreMessages(E);
 }
 
 ExtException::ExtException(TObjectClassId Kind, const UnicodeString & Msg, const Exception * E) :
@@ -464,7 +465,7 @@ EOSExtException::EOSExtException(TObjectClassId Kind, const UnicodeString & Msg,
 }
 
 EFatal::EFatal(TObjectClassId Kind, const UnicodeString & Msg, const Exception * E) :
-  ExtException(Kind, Msg)
+  ExtException(Kind, Msg, E)
 {
   const EFatal * F = rtti::dyn_cast_or_null<EFatal>(E);
   if (F != nullptr)

--- a/src/base/Exceptions.cpp
+++ b/src/base/Exceptions.cpp
@@ -319,13 +319,17 @@ ExtException::ExtException(TObjectClassId Kind, const UnicodeString & Msg, const
     {
       Message = Msg;
     }
-    else
+    else if (Message != Msg)
     {
       if (FMoreMessages == nullptr)
       {
         FMoreMessages = new TStringList();
       }
-      FMoreMessages->Append(UnformatMessage(Msg));
+      const auto PreparedMessage = UnformatMessage(Msg);
+      if (FMoreMessages->IndexOf(PreparedMessage) == nb::NPOS)
+      {
+        FMoreMessages->Append(PreparedMessage);
+      }
     }
   }
   // FHelpKeyword = MergeHelpKeyword(GetExceptionHelpKeyword(E), HelpKeyword);

--- a/src/base/Exceptions.h
+++ b/src/base/Exceptions.h
@@ -265,6 +265,16 @@ inline void ThrowNotImplemented(int32_t ErrorId)
   Error(SNotImplemented, ErrorId);
 }
 
+template<typename From, typename To>
+inline void TryReplaceAndThrow(Exception & E)
+{
+  if (rtti::isa<From>(&E))
+  {
+    throw To(E.Message);
+  }
+  throw; //NOSONAR
+}
+
 NB_CORE_EXPORT Exception * CloneException(Exception * E);
 NB_CORE_EXPORT void RethrowException(Exception * E);
 NB_CORE_EXPORT UnicodeString GetExceptionHelpKeyword(const Exception * E);

--- a/src/core/FtpFileSystem.cpp
+++ b/src/core/FtpFileSystem.cpp
@@ -3453,6 +3453,15 @@ UnicodeString TFTPFileSystem::GotReply(uint32_t Reply, uint32_t Flags,
         MoreMessages->Delete(0);
       }
 
+      if (MoreMessages != nullptr)
+      {
+        auto ErrorIndex = MoreMessages->IndexOf(Error);
+        if (ErrorIndex != nb::NPOS)
+        {
+          MoreMessages->Delete(ErrorIndex);
+        }
+      }
+
       if (Disconnected)
       {
         if (DoClose)

--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -1964,7 +1964,7 @@ void TTerminal::Reopen(int32_t Params)
     // only peek, we may not be connected at all atm,
     // so make sure we do not try retrieving current directory from the server
     // (particularly with FTP)
-    const UnicodeString CurrentDirectoryPeeked = CurrentDirectory();
+    const UnicodeString CurrentDirectoryPeeked = PeekCurrentDirectory();
     if (!CurrentDirectoryPeeked.IsEmpty())
     {
       GetSessionData()->SetRemoteDirectory(CurrentDirectoryPeeked);

--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -3828,7 +3828,14 @@ void TTerminal::CustomReadDirectory(TRemoteFileList * AFileList)
       if ((FOpening > 0) ||
           !RobustLoop.TryReopen(E))
       {
-        throw;
+        if (FOpening == 0)
+        {
+          TryReplaceAndThrow<EFatal, EAbort>(E);
+        }
+        else
+        {
+          throw;
+        }
       }
     }
   }
@@ -7787,7 +7794,7 @@ void TTerminal::SourceRobust(
         {
           RollbackAction(Action, AOperationProgress, &E);
         }
-        throw;
+        TryReplaceAndThrow<EFatal, EAbort>(E);
       }
     }
 
@@ -8402,7 +8409,7 @@ void TTerminal::SinkRobust(
           {
             RollbackAction(Action, AOperationProgress, &E);
           }
-          throw;
+          TryReplaceAndThrow<EFatal, EAbort>(E);
         }
       }
 


### PR DESCRIPTION
Some error messages are not shown. For example, when connecting to `FTP` with non-existent domain name nothing is shown, while other types of sessions show error message. In debug builds one can see an assertion: `Expression: ExceptionMessageFormatted(E, ExMessage) || !AQuery.IsEmpty()`.

The root cause: `EFatal` constructor forgot copying messages of external exception.

After fixing this problem, other problems were found:

1. Error messages may be duplicated.
2. Clicking `Abort` in the reconnect dialog shows redundant message that connection failed.
3. Reconnecting to an inacessible `FTP` leads to a crash.
4. In some cases the plugin panel is not closed when the connection is lost.

This PR fixes this problems.