### PR TITLE
Fix Internet protocol version options in Edit session dialog

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -3065,7 +3065,9 @@ void TSessionDialog::UpdateControls()
   }
   SshBufferSizeCheck->SetEnabled(lSshProtocol);
   PingNullPacketButton->SetEnabled(lSshProtocol);
-  IPAutoButton->SetEnabled(lSshProtocol);
+  IPAutoButton->SetEnabled(lSshProtocol || lFtpProtocol);
+  IPv4Button->SetEnabled(lSshProtocol || lFtpProtocol);
+  IPv6Button->SetEnabled(lSshProtocol || lFtpProtocol);
 
   // SFTP tab
   SftpTab->SetEnabled(lSftpProtocol);


### PR DESCRIPTION
Edit session dialog has `Internet protocol version` options on the `Connection` tab. They have two problems:

1. When this options are disabled, only `Auto` option is disabled, allowing other options (`IPv4`, `IPv6`) to be selected
2. This options are disabled for `FTP`, whereas they should be enabled for `FTP`, `SCP`, and `SFTP`

This PR fixes that issues.