### PR TITLE
Don't unexpectedly change Transfer settings

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -566,7 +566,7 @@ bool TWinSCPPlugin::TransferConfigurationDialog()
   const UnicodeString Caption = FORMAT("%s - %s",
     GetMsg(NB_PLUGIN_TITLE), ::StripHotkey(GetMsg(NB_CONFIG_TRANSFER)));
 
-  TGUICopyParamType & CopyParam = GetGUIConfiguration()->GetDefaultCopyParam();
+  TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
   const bool Result = CopyParamDialog(Caption, CopyParam, 0);
   if (Result)
   {
@@ -677,7 +677,7 @@ bool TWinSCPPlugin::EnduranceConfigurationDialog()
 
   Dialog->AddStandardButtons();
 
-  TGUICopyParamType & CopyParam = GetGUIConfiguration()->GetDefaultCopyParam();
+  TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
   ResumeOnButton->SetChecked(CopyParam.GetResumeSupport() == rsOn);
   ResumeSmartButton->SetChecked(CopyParam.GetResumeSupport() == rsSmart);
   ResumeOffButton->SetChecked(CopyParam.GetResumeSupport() == rsOff);
@@ -778,7 +778,7 @@ bool TWinSCPPlugin::QueueConfigurationDialog()
     GetConfiguration()->BeginUpdate();
     try__finally
     {
-      TGUICopyParamType & CopyParam = GetGUIConfiguration()->GetDefaultCopyParam();
+      TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
 
       FarConfiguration->SetQueueTransfersLimit(QueueTransferLimitEdit->GetAsInteger());
       CopyParam.SetQueue(QueueCheck->GetChecked());

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -1306,7 +1306,8 @@ void TWinSCPFileSystem::ApplyCommand()
 
           UnicodeString TempDir;
 
-          TemporarilyDownloadFiles(FileList.get(), GetGUIConfiguration()->GetDefaultCopyParam(), TempDir);
+          TGUICopyParamType CopyParam(GetGUIConfiguration()->GetDefaultCopyParam());
+          TemporarilyDownloadFiles(FileList.get(), CopyParam, TempDir);
           try__finally
           {
             RemoteFileList = std::make_unique<TStringList>();


### PR DESCRIPTION
Default `Transfer settings` can be changed unexpectedly, for example when using `Apply Command (Ctrl-G)` in `Local command` mode.

Steps to reproduce:

1. `F11` => `NetBox commands` => `Configure` => `Transfer settings`
2. Ensure that `Preserve read-only` option is set
3. Open `SCP` session, select some text file and press `Ctrl-G`
4. Enter `notepad.exe !` command, select `Local command` and press `Ok`
5. Close notepad
6. Follow step 1 and see that `Preserve read-only` option is clear

This PR fixes the issue.