### PR TITLE
Fix updating session on import

### DIFF
--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -5409,6 +5409,11 @@ void TStoredSessionList::Load(THierarchicalStorage * Storage,
             SessionData->Load(Storage, PuttyImport);  // gh-364
             Add(SessionData);
           }
+          else if (AsModified)
+          {
+            // import existing session: just update
+            SessionData->Load(Storage, PuttyImport);
+          }
           Loaded->Add(SessionData);
           // line moved up, gh-364: SessionData->Load(Storage, PuttyImport);
           if (AsModified)


### PR DESCRIPTION
This PR fixes a regression: when importing a `.netbox` file into the session list, an already existing session is not updated.