### PR TITLE
Fix unexpected session closure when clicking Abort

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -325,7 +325,7 @@ void TWinSCPFileSystem::HandleException(Exception * E, OPERATION_MODES OpMode)
       DoClose = true;
     }
   }
-  else if ((GetTerminal() != nullptr) && rtti::isa<EAbort>(E))
+  else if ((GetTerminal() != nullptr) && rtti::isa<EAbort>(E) && E->Message == EXCEPTION_MSG_REPLACED)
   {
     DoClose = true;
   }

--- a/src/base/Exceptions.h
+++ b/src/base/Exceptions.h
@@ -249,9 +249,9 @@ public:
   }
 };
 
-inline void Abort()
+inline void Abort(const UnicodeString & Message = "")
 {
-  throw EAbort("");
+  throw EAbort(Message);
 }
 
 inline void Error(int32_t Id, int32_t ErrorId)
@@ -265,12 +265,14 @@ inline void ThrowNotImplemented(int32_t ErrorId)
   Error(SNotImplemented, ErrorId);
 }
 
+constexpr const auto * EXCEPTION_MSG_REPLACED = L"[replaced]";
+
 template<typename From, typename To>
 inline void TryReplaceAndThrow(Exception & E)
 {
   if (rtti::isa<From>(&E))
   {
-    throw To(E.Message);
+    throw To(EXCEPTION_MSG_REPLACED);
   }
   throw; //NOSONAR
 }

--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -3087,7 +3087,7 @@ uint32_t TTerminal::CommandError(Exception * E, const UnicodeString & AMsg,
   else if (E && rtti::isa<EAbort>(E))
   {
     // resent EAbort exception
-    Abort();
+    Abort(E->Message);
   }
   else if (GetExceptionOnFail())
   {


### PR DESCRIPTION
When deleting a file without a permission, an error dialog is shown. Clicking`Abort` closes the session, but it shouldn't.

This became possible due to insufficient handling of `EAbort` exception, that needs additional checks in order not to interfere with `Abort()` calls. The bug was introduced in commits `3119992cd601b2e60a10b4362217357e8ed5b981` and `33d435a836ede3c8e2ad56fb9904259037312d11`.

This pull request fixes a regression introduced in the PR #473.