### PR TITLE
Fix writing code page to database

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -3752,9 +3752,7 @@ bool TSessionDialog::Execute(TSessionData * SessionData, TSessionActionEnum & Ac
     {
       SessionData->SetAddressFamily(afAuto);
     }
-    SessionData->SetCodePage(
-      (CodePageEdit->GetText() == CodePageEdit->GetItems()->GetString(0)) ?
-      UnicodeString() : CodePageEdit->GetText());
+    SessionData->SetCodePage(CodePageEdit->GetText());
 
     // Proxy tab
     SessionData->SetProxyMethod(GetProxyMethod());


### PR DESCRIPTION
There is a problem with storing the session setting `Charset encoding for filenames` to the settings database.

Steps to reproduce:

1. Press `F4` on some session in the session list
2. Edit `Charset encoding for filenames`: change to `1251`
3. Save session, exit `Far`, start `Far`
4. Check `Charset encoding for filenames`, it should be equal to `1251`
5. Change `Charset encoding for filenames`: select the first element from the drop-down menu (`65001 (UTF-8)`)
6. Save session, exit `Far`, start `Far`
7. Check `Charset encoding for filenames` again: it is set to `1251` instead of `65001 (UTF-8)`

This pull request fixes the problem. It just prevents setting empty code page (aka default value). This way, the correct value will be written to the database later.
