### PR TITLE
Fix user/password labels appearing on wrong tab

### DIFF
--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -3060,12 +3060,14 @@ void TSessionDialog::UpdateControls()
 //  HostNameLabel->SetCaption(GetMsg(NB_LOGIN_HOST_NAME));
 
   UserNameEdit->SetEnabled(!LoginAnonymous);
+  UserNameEdit->SetVisible(IsMainTab);
   PasswordEdit->SetEnabled(!LoginAnonymous);
+  PasswordEdit->SetVisible(IsMainTab);
 
-  UserNameLabel->SetVisible(!lS3Protocol);
-  S3AccessKeyIDLabel->SetVisible(lS3Protocol);
-  PasswordLabel->SetVisible(!lS3Protocol);
-  S3SecretAccessKeyLabel->SetVisible(lS3Protocol);
+  UserNameLabel->SetVisible(IsMainTab && !lS3Protocol);
+  S3AccessKeyIDLabel->SetVisible(IsMainTab && lS3Protocol);
+  PasswordLabel->SetVisible(IsMainTab && !lS3Protocol);
+  S3SecretAccessKeyLabel->SetVisible(IsMainTab && lS3Protocol);
 
   // Connection sheet
   FtpPasvModeCheck->SetEnabled(lFtpProtocol);


### PR DESCRIPTION
This pull request fixes a bug reported on the [farmanager forum](https://forum.farmanager.com/viewtopic.php?p=178742#p178742).

The bug was introduced by mistake in commit `91fc6250fbe0bf2c028994aeb452ae46708c0421`.