### PR TITLE
Fix focusing of new and duplicated sessions

### DIFF
--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -6041,12 +6041,12 @@ TSessionData * TStoredSessionList::NewSession(
   TSessionData * DuplicateSession = rtti::dyn_cast_or_null<TSessionData>(FindByName(SessionName));
   if (!DuplicateSession)
   {
-    std::unique_ptr<TSessionData> DuplicateSession = std::make_unique<TSessionData>("");
+    DuplicateSession = new TSessionData(L"");
     DuplicateSession->Assign(Session);
     DuplicateSession->SetName(SessionName);
     // make sure, that new stored session is saved to registry
     DuplicateSession->SetModified(true);
-    Add(DuplicateSession.release());
+    Add(DuplicateSession);
   }
   else
   {


### PR DESCRIPTION
In rather old versions of the plugin the newly created session (`Shift-F4`) or the duplicated one (`Shift-F5`) received focus. This is not true with recent versions.

The root cause of the problem is `TStoredSessionList::NewSession` function, that returns nullptr when the new session is created. This PR fixes it.