### PR TITLE
Don't treat netbox file as archive when searching in archives

### DIFF
--- a/src/NetBox/FarDialog.cpp
+++ b/src/NetBox/FarDialog.cpp
@@ -772,7 +772,7 @@ int32_t TFarDialog::ShowModal()
         GetItemCount(), 0, GetFlags(),
         TFarDialog::DialogProcGeneral,
         nb::ToPtr(this));
-      BResult = Info.DialogRun(Handle);
+      BResult = CheckHandle(Handle) ? Info.DialogRun(Handle) : -1;
     }
 
     if (BResult >= 0)

--- a/src/NetBox/NetBox.cpp
+++ b/src/NetBox/NetBox.cpp
@@ -234,6 +234,10 @@ HANDLE WINAPI AnalyseW(const struct AnalyseInfo * Info)
   if (!Info || (Info->StructSize < sizeof(AnalyseInfo)))
     return nullptr;
   const TFarPluginGuard Guard;
+  if (Info->OpMode & (OPM_FIND | OPM_COMMANDS))
+  {
+    return nullptr;
+  }
   if (!Info->FileName)
   {
     return nullptr;

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4922,7 +4922,6 @@ TPropertiesDialog::TPropertiesDialog(TCustomFarPlugin * AFarPlugin,
     }
     MsgText->SetRight(-6);
     MsgText->SetFlag(DIF_CENTERTEXT, true);
-    Text->SetFlag(DIF_WORDWRAP, true);
     const TRemoteFile * File = AFileList->GetAs<TRemoteFile>(0);
     if (!File->GetLinkTo().IsEmpty())
     {


### PR DESCRIPTION
This PR fixes #493

1. It fixes `ShowModal` that can crash if `DialogInit` returned an invalid handle.
2. Moreover, it disables very confusing behaviour — connecting to the servers when processing  `.netbox` files on `Alt-F7` (with `[x] Search in archives`) and `Shift-F3` (Archive command).

In addition to this fixes, this PR also cleans some remainings of an old PR.