### PR TITLE
Fix SCP terminal command execution

### DIFF
--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -912,6 +912,7 @@ bool TWinSCPFileSystem::ExecuteCommand(const UnicodeString & Command)
       if (FTerminal->GetActive())
       {
         UpdatePanel();
+        RedrawPanel();
       }
       else
       {

--- a/src/core/ScpFileSystem.cpp
+++ b/src/core/ScpFileSystem.cpp
@@ -32,6 +32,7 @@ constexpr int32_t ecIgnoreWarnings = 0x02;
 constexpr int32_t ecReadProgress = 0x04;
 constexpr int32_t ecIgnoreStdErr = 0x08;
 constexpr int32_t ecNoEnsureLocation = 0x10;
+constexpr int32_t ecOnlyReturnCode = 0x20;
 constexpr int32_t ecDefault = ecRaiseExcept;
 //---------------------------------------------------------------------------
 DERIVE_EXT_EXCEPTION(EScpFileSkipped, ESkipFile);
@@ -731,6 +732,7 @@ void TSCPFileSystem::ExecCommand(TFSCommand Cmd, int32_t Params,
   const int32_t COParams =
     coWaitForLastLine |
     FLAGMASK(FLAGSET(Params, ecRaiseExcept), coRaiseExcept) |
+    FLAGMASK(FLAGSET(Params, ecOnlyReturnCode), coOnlyReturnCode) |
     FLAGMASK(FLAGSET(Params, ecIgnoreWarnings), coIgnoreWarnings) |
     FLAGMASK(FLAGSET(Params, ecReadProgress), coReadProgress) |
     FLAGMASK(FLAGSET(Params, ecIgnoreStdErr), coIgnoreStdErr);
@@ -1627,7 +1629,7 @@ void TSCPFileSystem::AnyCommand(const UnicodeString & Command,
   try__finally
   {
     const int32_t Params =
-      ecDefault |
+       ecDefault | ecOnlyReturnCode |
       (FTerminal->SessionData->GetExitCode1IsError() ? ecIgnoreStdErr : ecIgnoreWarnings);
 
     ExecCommand(fsAnyCommand, Params, Command);


### PR DESCRIPTION
This PR fixes issues that are related to executing commands in `SCP` terminal:

1. Panel is not refreshed. For example, after executing `touch test.txt` (execute command while panels are shown) the resulting file is not shown on the panel.
2. If a command completed successfuly (exit code 0, or maybe 1) but has some stderr output, it shows error message. This is particularly annoying for commands like `wget` (and many others) that can output normally to both stdout and stderr.
