### PR TITLE
Fix RTTI class IDs

### DIFF
--- a/src/NetBox/FarDialog.cpp
+++ b/src/NetBox/FarDialog.cpp
@@ -15,7 +15,6 @@ inline TRect Rect(int32_t Left, int32_t Top, int32_t Right, int32_t Bottom)
   return TRect(Left, Top, Right, Bottom);
 }
 
-constexpr const TObjectClassId OBJECT_CLASS_TDialogIdleThread = static_cast<TObjectClassId>(nb::counter_id());
 class TFarDialogIdleThread final : public TSimpleThread
 {
 public:

--- a/src/NetBox/FarPlugin.cpp
+++ b/src/NetBox/FarPlugin.cpp
@@ -1575,7 +1575,6 @@ void TCustomFarPlugin::SaveTerminalScreen()
   FarControl(FCTL_SETUSERSCREEN, 0, nullptr);
 }
 
-const TObjectClassId OBJECT_CLASS_TConsoleTitleParam = static_cast<TObjectClassId>(nb::counter_id());
 class TConsoleTitleParam : public TObject
 {
 public:

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -239,7 +239,6 @@ void TFarInteractiveCustomCommand::Prompt(int32_t /*Index*/, const UnicodeString
 
 // Attempt to allow keepalives from background thread.
 // Not finished nor used.
-const TObjectClassId OBJECT_CLASS_TKeepAliveThread = static_cast<TObjectClassId>(nb::counter_id());
 class TKeepAliveThread final : public TSimpleThread
 {
 public:

--- a/src/base/ObjIDs.cpp
+++ b/src/base/ObjIDs.cpp
@@ -151,4 +151,10 @@ const TObjectClassId OBJECT_CLASS_TRemoteFilePanelItem = static_cast<TObjectClas
 const TObjectClassId OBJECT_CLASS_TWinSCPPlugin = static_cast<TObjectClassId>(nb::counter_id());
 const TObjectClassId OBJECT_CLASS_TFarMessageData = static_cast<TObjectClassId>(nb::counter_id());
 
+const TObjectClassId OBJECT_CLASS_TTerminalItem = static_cast<TObjectClassId>(nb::counter_id());
+const TObjectClassId OBJECT_CLASS_TBackgroundTerminal = static_cast<TObjectClassId>(nb::counter_id());
+const TObjectClassId OBJECT_CLASS_TDialogIdleThread = static_cast<TObjectClassId>(nb::counter_id());
+const TObjectClassId OBJECT_CLASS_TConsoleTitleParam = static_cast<TObjectClassId>(nb::counter_id());
+const TObjectClassId OBJECT_CLASS_TKeepAliveThread = static_cast<TObjectClassId>(nb::counter_id());
+
 } // extern "C"

--- a/src/base/ObjIDs.h
+++ b/src/base/ObjIDs.h
@@ -146,5 +146,11 @@ extern const TObjectClassId OBJECT_CLASS_TRightsContainer;
 extern const TObjectClassId OBJECT_CLASS_TCopyParamsContainer;
 extern const TObjectClassId OBJECT_CLASS_TLabelList;
 
+extern const TObjectClassId OBJECT_CLASS_TTerminalItem;
+extern const TObjectClassId OBJECT_CLASS_TBackgroundTerminal;
+extern const TObjectClassId OBJECT_CLASS_TDialogIdleThread;
+extern const TObjectClassId OBJECT_CLASS_TConsoleTitleParam;
+extern const TObjectClassId OBJECT_CLASS_TKeepAliveThread;
+
 } // extern "C"
 

--- a/src/core/Queue.cpp
+++ b/src/core/Queue.cpp
@@ -243,7 +243,6 @@ public:
   bool Cancel{false};
 };
 
-constexpr TObjectClassId OBJECT_CLASS_TTerminalItem = static_cast<TObjectClassId>(nb::counter_id());
 class TTerminalItem final : public TSignalThread
 {
   friend class TQueueItem;
@@ -1250,7 +1249,6 @@ bool TTerminalQueue::ContinueParallelOperation() const
 
 // TBackgroundItem
 
-constexpr TObjectClassId OBJECT_CLASS_TBackgroundTerminal = static_cast<TObjectClassId>(nb::counter_id());
 class TBackgroundTerminal final : public TSecondaryTerminal
 {
   friend class TTerminalItem;

--- a/src/include/rtti.hpp
+++ b/src/include/rtti.hpp
@@ -968,7 +968,7 @@ struct depth
 template<int N>
 struct mark
 {
-  friend constexpr int adl_flag(flag<N>) { return N; }
+  friend constexpr int adl_flag(flag<N>) noexcept { return N; }
   static constexpr int value = N;
 };
 


### PR DESCRIPTION
This PR fixes two issues:

1. The new version of msvc (version 19.42) bundled with Visual Studio 2022 version 17.12 breaks `nb::counter_id()` hack because of [this](https://learn.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#constant-expressions-are-no-longer-always-noexcept-in-permissive-mode) change. This may lead to crashes.
2. Several object IDs like `OBJECT_CLASS_TTerminalItem` get wrong values because they are defined in different translation units, so `nb::counter_id()` is reset to 1 in each of them.

P.S. `nb::counter_id()` hack works only in msvc for a long time now. Perhaps it's better to use `__COUNTER__` macro that works in all major compilers: `msvc`, `gcc`, `clang`.