### PR TITLE
Убрал из README.ru заявление, что работает с FAR2

### DIFF
--- a/README.RU.md
+++ b/README.RU.md
@@ -1,4 +1,4 @@
-NetBox: SFTP/FTP(S)/SCP/WebDAV клиент для Far Manager 2.0/3.0
+NetBox: SFTP/FTP(S)/SCP/WebDAV клиент для Far Manager 3.0
 ===============
 
 1. Общие сведения о плагине


### PR DESCRIPTION
Последняя версия, которая работает с Far2, была 2.4.3