### PR TITLE
Remove extra Plugins directory from 7z artefacts as it was before

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
 
           # Main archive (exclude PDB files)
           echo "Creating main archive: ${{ env.netbox_name }}"
-          7z a -m0=LZMA -mf=BCJ2 -mx9 "${{ env.netbox_name }}" "${PLUGIN_DIR}/" -xr!*.pdb
+          7z a -m0=LZMA -mf=BCJ2 -mx9 "${{ env.netbox_name }}" "${PLUGIN_DIR}/*" -xr!*.pdb
 
           # PDB archive (only if exists)
           PDB_FILE="${PLUGIN_DIR}/NetBox/NetBox.pdb"

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4126,6 +4126,7 @@ TSessionDialog::TSessionDialog(TCustomFarPlugin * AFarPlugin, TSessionActionEnum
     SFTPMaxVersionCombo->GetItems()->Add(::IntToStr(Index2));
   }
   Text->SetEnabledFollow(SFTPMaxVersionCombo);
+  SetNextItemPosition(ipNewLine);
 
   // SFTP RealPath and POSIX rename
   Text = MakeOwnedObject<TFarText>(this);

--- a/src/NetBox/WinSCPDialogs.cpp
+++ b/src/NetBox/WinSCPDialogs.cpp
@@ -4137,10 +4137,10 @@ TSessionDialog::TSessionDialog(TCustomFarPlugin * AFarPlugin, TSessionActionEnum
   SFTPRealPathCombo->GetItems()->Add(GetMsg(NB_LOGIN_BUGS_OFF));
   SFTPRealPathCombo->GetItems()->Add(GetMsg(NB_LOGIN_BUGS_ON));
   Text->SetEnabledFollow(SFTPRealPathCombo);
+  SetNextItemPosition(ipNewLine);
 
   UsePosixRenameCheck = MakeOwnedObject<TFarCheckBox>(this);
   UsePosixRenameCheck->SetCaption(GetMsg(NB_LOGIN_SFTP_POSIX_RENAME));
-  SetNextItemPosition(ipNewLine);
 
   Separator = MakeOwnedObject<TFarSeparator>(this);
   Separator->SetCaption(GetMsg(NB_LOGIN_SFTP_BUGS_GROUP));

--- a/src/NetBox/WinSCPFileSystem.cpp
+++ b/src/NetBox/WinSCPFileSystem.cpp
@@ -2545,19 +2545,22 @@ bool TWinSCPFileSystem::SetDirectoryEx(const UnicodeString & ADir, OPERATION_MOD
     }
     try__finally
     {
-      if (ADir == BACKSLASH)
+      if (FTerminal)
       {
-        FTerminal->ChangeDirectory(ROOTDIRECTORY);
-      }
-      else if ((ADir == PARENTDIRECTORY) && (FTerminal->GetCurrentDirectory() == ROOTDIRECTORY))
-      {
-        // ClosePanel();
-        Disconnect();
-      }
-      else
-      {
-        FTerminal->ChangeDirectory(ADir);
-        FCurrentDirectoryWasChanged = true;
+        if (ADir == BACKSLASH)
+        {
+          FTerminal->ChangeDirectory(ROOTDIRECTORY);
+        }
+        else if ((ADir == PARENTDIRECTORY) && (FTerminal->GetCurrentDirectory() == ROOTDIRECTORY))
+        {
+          // ClosePanel();
+          Disconnect();
+        }
+        else
+        {
+          FTerminal->ChangeDirectory(ADir);
+          FCurrentDirectoryWasChanged = true;
+        }
       }
     }
     __finally

--- a/src/core/Cryptography.cpp
+++ b/src/core/Cryptography.cpp
@@ -68,7 +68,7 @@
 
 constexpr const int32_t IN_BLOCK_LENGTH     = 64;
 constexpr const int32_t OUT_BLOCK_LENGTH    = 20;
-constexpr const int32_t HMAC_IN_DATA        = 0xffffffff;
+constexpr const uint32_t HMAC_IN_DATA       = 0xffffffff;
 
 struct hmac_ctx
 {

--- a/src/core/SecureShell.cpp
+++ b/src/core/SecureShell.cpp
@@ -1853,7 +1853,7 @@ void TSecureShell::PuttyFatalError(const UnicodeString & AError)
   }
 }
 
-void TSecureShell::FatalError(const UnicodeString & Error, const UnicodeString & HelpKeyword)
+NORETURN void TSecureShell::FatalError(const UnicodeString & Error, const UnicodeString & HelpKeyword)
 {
   FUI->FatalError(nullptr, Error, HelpKeyword);
 }

--- a/src/core/SecureShell.cpp
+++ b/src/core/SecureShell.cpp
@@ -1189,7 +1189,7 @@ void TSecureShell::FromBackend(const uint8_t * Data, size_t Length)
 
   if (Len > 0)
   {
-    if (PendSize < PendLen + Len)
+    if (PendSize < PendLen + Len || !Pending)
     {
       PendSize = PendLen + Len + 4096;
       Pending = nb::ToUInt8Ptr(

--- a/src/core/SecureShell.h
+++ b/src/core/SecureShell.h
@@ -146,7 +146,7 @@ protected:
   int32_t TranslateErrorMessage(UnicodeString & Message, UnicodeString * HelpKeyword = nullptr);
   void AddStdErrorLine(const UnicodeString & AStr);
   void LogEvent(const UnicodeString & AStr);
-  void FatalError(const UnicodeString & Error, const UnicodeString & HelpKeyword = "");
+  NORETURN void FatalError(const UnicodeString & Error, const UnicodeString & HelpKeyword = "");
   UnicodeString FormatKeyStr(const UnicodeString & AKeyStr) const;
   void ParseFingerprint(const UnicodeString & Fingerprint, UnicodeString & SignKeyType, UnicodeString & Hash);
   Conf * StoreToConfig(TSessionData * Data, bool Simple);

--- a/src/core/Terminal.cpp
+++ b/src/core/Terminal.cpp
@@ -2729,7 +2729,10 @@ bool TTerminal::FileOperationLoopQuery(Exception & E,
     if (Answer == qaAll)
     {
       DebugAssert(AOperationProgress != nullptr);
-      AOperationProgress->SetSkipToAll();
+      if (AOperationProgress != nullptr)
+      {
+        AOperationProgress->SetSkipToAll();
+      }
       Answer = qaSkip;
     }
     if (Answer == qaYes)


### PR DESCRIPTION
In recent releases there's an extra directory in 7z artefacts, `Plugins`.

Old:

```
7z l NetBox.x64.24.12.2.608.163.7z
```
```
   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2024-12-20 04:32:29 D....            0            0  NetBox
2024-12-20 04:32:30 ....A         3034      3044429  NetBox\cacert.pem
2024-12-20 04:32:29 ....A        63390               NetBox\ChangeLog
2024-12-20 04:32:29 ....A        18431               NetBox\LICENSE.txt
2024-12-20 04:32:29 ....A      7891456               NetBox\NetBox.dll
2024-12-20 04:32:29 ....A      9245941               NetBox\NetBox.map
2024-12-20 04:32:29 ....A        42758               NetBox\NetBoxEng.lng
2024-12-20 04:32:29 ....A        46398               NetBox\NetBoxPol.lng
2024-12-20 04:32:30 ....A        54636               NetBox\NetBoxRus.lng
2024-12-20 04:32:30 ....A        44670               NetBox\NetBoxSpa.lng
2024-12-20 04:32:29 ....A         3190               NetBox\README.md
2024-12-20 04:32:29 ....A         3385               NetBox\README.PL.md
2024-12-20 04:32:29 ....A         4557               NetBox\README.RU.md
------------------- ----- ------------ ------------  ------------------------
2024-12-20 04:32:30           17421846      3044429  12 files, 1 folders
```
New:

```
7z l NetBox.x64.26.5.3.612.174.7z
```
```
   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2026-05-26 05:35:38 D....            0            0  Plugins
2026-05-26 05:38:19 D....            0            0  Plugins\NetBox
2026-05-26 05:38:19 ....A        13797      2996116  Plugins\NetBox\ChangeLog
2026-05-26 05:38:19 ....A        18431               Plugins\NetBox\LICENSE.txt
2026-05-26 05:38:19 ....A      6884864               Plugins\NetBox\NetBox.dll
2026-05-26 05:38:19 ....A        17108               Plugins\NetBox\NetBox.en.hlf
2026-05-26 05:38:19 ....A     11002293               Plugins\NetBox\NetBox.map
2026-05-26 05:38:19 ....A        29188               Plugins\NetBox\NetBox.ru.hlf
2026-05-26 05:35:38 ....A        46600               Plugins\NetBox\NetBoxEng.lng
2026-05-26 05:35:38 ....A        47248               Plugins\NetBox\NetBoxFr.lng
2026-05-26 05:35:39 ....A        50373               Plugins\NetBox\NetBoxPol.lng
2026-05-26 05:35:39 ....A        59815               Plugins\NetBox\NetBoxRus.lng
2026-05-26 05:35:39 ....A        48772               Plugins\NetBox\NetBoxSpa.lng
2026-05-26 05:38:19 ....A         1892               Plugins\NetBox\README.md
------------------- ----- ------------ ------------  ------------------------
2026-05-26 05:38:19           18220381      2996116  12 files, 2 folders
```

It is not expected and breaks Far build:
https://ci.appveyor.com/project/FarGroup/farmanager/builds/54120475/job/h5nfwvbbbadpl0g1

Looks like it was changed [here](https://github.com/michaellukashov/Far-NetBox/commit/4cae05b13e70743940df0e7d4651d290e5c22e8a#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34):


Before:
`7z a -m0=LZMA -mf=BCJ2 -mx9 ${{ env.netbox_name }} ./Far3_${{ matrix.platform }}/Plugins/* -xr!*.pdb`
After:
`7z a -m0=LZMA -mf=BCJ2 -mx9 "${{ env.netbox_name }}" "${PLUGIN_DIR}/" -xr!*.pdb`

Where PLUGIN_DIR is `"./Far3_${{ matrix.platform }}/Plugins"`

Notice that after the change there is no `*` after `Plugins/`
This PR restores it as it was.


